### PR TITLE
fix: read, modify and write back files.watcherExclude setting for han…

### DIFF
--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -86,11 +86,9 @@ export async function activate(context: ExtensionContext): Promise<void> {
   }
 
   // enable fileWatcher to watch .prisma folder inside node_modules
-  const config: WorkspaceConfiguration = workspace.getConfiguration()
-  console.log('config')
-  console.log(config)
-  const filesWatcherConfig = config.get('files.watcherExclude', '')
-  try {
+  if (!isDebugOrTestSession()) {
+    const config: WorkspaceConfiguration = workspace.getConfiguration()
+    const filesWatcherConfig = config.get('files.watcherExclude', '')
     const value = JSON.parse(filesWatcherConfig)
     if (value['**/node_modules/*/**']) {
       // Copy boolean value
@@ -105,10 +103,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
         console.error('Updating user setting files.watcherExclude failed')
         console.error(err)
       }
-    }
-  } catch (err) {
-    if (err instanceof SyntaxError) {
-      console.log(err)
     }
   }
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -88,19 +88,25 @@ export async function activate(context: ExtensionContext): Promise<void> {
   // enable fileWatcher to watch .prisma folder inside node_modules
   const config: WorkspaceConfiguration = workspace.getConfiguration()
   const filesWatcherConfig = config.get('files.watcherExclude', '')
-  const value = JSON.parse(filesWatcherConfig)
-  if (value['**/node_modules/*/**']) {
-    // Copy boolean value
-    value['**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*'] =
-      value['**/node_modules/*/**']
-    // Delete original exclude
-    delete value['**/node_modules/*/**']
-    try {
-      await config.update('files.watcherExclude', JSON.stringify(value))
-      console.log('Successfully updated setting files.watcherExclude')
-    } catch (err) {
-      console.error('Updating user setting files.watcherExclude failed')
-      console.error(err)
+  try {
+    const value = JSON.parse(filesWatcherConfig)
+    if (value['**/node_modules/*/**']) {
+      // Copy boolean value
+      value['**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*'] =
+        value['**/node_modules/*/**']
+      // Delete original exclude
+      delete value['**/node_modules/*/**']
+      try {
+        await config.update('files.watcherExclude', JSON.stringify(value))
+        console.log('Successfully updated setting files.watcherExclude')
+      } catch (err) {
+        console.error('Updating user setting files.watcherExclude failed')
+        console.error(err)
+      }
+    }
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      console.log(err)
     }
   }
 

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -87,6 +87,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // enable fileWatcher to watch .prisma folder inside node_modules
   const config: WorkspaceConfiguration = workspace.getConfiguration()
+  console.log('config')
+  console.log(config)
   const filesWatcherConfig = config.get('files.watcherExclude', '')
   try {
     const value = JSON.parse(filesWatcherConfig)

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -88,7 +88,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   // enable fileWatcher to watch .prisma folder inside node_modules
   if (!isDebugOrTestSession()) {
     const config: WorkspaceConfiguration = workspace.getConfiguration()
-    const filesWatcherConfig = config.get('files.watcherExclude', '')
+    const filesWatcherConfig = config.get('files.watcherExclude', '{}')
     const value = JSON.parse(filesWatcherConfig)
     if (value['**/node_modules/*/**']) {
       // Copy boolean value

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -87,7 +87,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // enable fileWatcher to watch .prisma folder inside node_modules
   const config: WorkspaceConfiguration = workspace.getConfiguration()
-  const value: string = JSON.stringify(config.get('files.watcherExclude'))
+  const value: string = JSON.stringify(config.get('files.watcherExclude', ''))
   if (value.includes('**/node_modules/*/**')) {
     const replacedValue = value.replace(
       '**/node_modules/*/**',

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -87,15 +87,16 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // enable fileWatcher to watch .prisma folder inside node_modules
   const config: WorkspaceConfiguration = workspace.getConfiguration()
-  const value: string = config.get('files.watcherExclude', '')
-  if (value.includes('**/node_modules/*/**')) {
-    const replacedValue = value.replace(
-      '**/node_modules/*/**',
-      // This is a way to except node_modules/.prisma folder from the exclude, see: https://github.com/microsoft/vscode/issues/869#issuecomment-630086813
-      '**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*',
-    )
+  const filesWatcherConfig = config.get('files.watcherExclude', '')
+  const value = JSON.parse(filesWatcherConfig)
+  if (value['**/node_modules/*/**']) {
+    // Copy boolean value
+    value['**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*'] =
+      value['**/node_modules/*/**']
+    // Delete original exclude
+    delete value['**/node_modules/*/**']
     try {
-      await config.update('files.watcherExclude', replacedValue)
+      await config.update('files.watcherExclude', JSON.stringify(value))
       console.log('Successfully updated setting files.watcherExclude')
     } catch (err) {
       console.error('Updating user setting files.watcherExclude failed')

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -91,6 +91,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   if (value.includes('**/node_modules/*/**')) {
     const replacedValue = value.replace(
       '**/node_modules/*/**',
+      // This is a way to except node_modules/.prisma folder from the exclude, see: https://github.com/microsoft/vscode/issues/869#issuecomment-630086813
       '**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*',
     )
     try {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -19,6 +19,7 @@ import {
   CodeAction,
   Command,
   workspace,
+  WorkspaceConfiguration,
 } from 'vscode'
 import { Telemetry, TelemetryPayload, ExceptionPayload } from './telemetry'
 import path from 'path'
@@ -85,9 +86,8 @@ export async function activate(context: ExtensionContext): Promise<void> {
   }
 
   // enable fileWatcher to watch .prisma folder inside node_modules
-  const value: string = JSON.stringify(
-    workspace.getConfiguration().get('files.watcherExclude'),
-  )
+  const config: WorkspaceConfiguration = workspace.getConfiguration()
+  const value: string = JSON.stringify(config.get('files.watcherExclude'))
   if (value.includes('**/node_modules/*/**')) {
     const replacedValue = value.replace(
       '**/node_modules/*/**',
@@ -95,9 +95,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       '**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*',
     )
     try {
-      await workspace
-        .getConfiguration()
-        .update('files.watcherExclude', replacedValue)
+      await config.update('files.watcherExclude', replacedValue)
       console.log('Successfully updated setting files.watcherExclude')
     } catch (err) {
       console.error('Updating user setting files.watcherExclude failed')

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -84,6 +84,26 @@ export async function activate(context: ExtensionContext): Promise<void> {
     },
   }
 
+  // enable fileWatcher to watch .prisma folder inside node_modules
+  const value: string = JSON.stringify(
+    workspace.getConfiguration().get('files.watcherExclude'),
+  )
+  if (value.includes('**/node_modules/*/**')) {
+    const replacedValue = value.replace(
+      '**/node_modules/*/**',
+      '**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*',
+    )
+    try {
+      await workspace
+        .getConfiguration()
+        .update('files.watcherExclude', replacedValue)
+      console.log('Successfully updated setting files.watcherExclude')
+    } catch (err) {
+      console.error('Updating user setting files.watcherExclude failed')
+      console.error(err)
+    }
+  }
+
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {
     // Register the server for prisma documents

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -87,7 +87,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
   // enable fileWatcher to watch .prisma folder inside node_modules
   const config: WorkspaceConfiguration = workspace.getConfiguration()
-  const value: string = JSON.stringify(config.get('files.watcherExclude', ''))
+  const value: string = config.get('files.watcherExclude', '')
   if (value.includes('**/node_modules/*/**')) {
     const replacedValue = value.replace(
       '**/node_modules/*/**',


### PR DESCRIPTION
…ging types issue

In order for https://github.com/prisma/language-tools/pull/357 to work, the `.prisma/` folder has to be watched by the LSP. This is only possible if the default setting 
```
"files.watcherExclude":
 '**/node_modules/*/**'
```

is replaced with 
```
"files.watcherExclude":
 '**/node_modules/{[^.],?[^p],??[^r],???[^i],????[^s],?????[^m]}*'
```