### PR TITLE
build: serialize workflow runs for insider

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,6 @@
 name: CI tests
 
-on: [push]
+on: [pull_request]
     
 
 jobs:

--- a/.github/workflows/patch-CLI.yml
+++ b/.github/workflows/patch-CLI.yml
@@ -2,8 +2,8 @@ name: Check for Update + Patch Release
 
 on:
   schedule:
-  # the script takes about 12 minutes, so in order to not have two processes start together, this is set to 15
-    - cron: '*/15 * * * *'
+  # the script takes about 12-19 minutes, so in order to not have two processes start together, this is set to 20
+    - cron: '*/20 * * * *'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-insider-check-CLI.yml
+++ b/.github/workflows/publish-insider-check-CLI.yml
@@ -19,6 +19,9 @@ jobs:
       lsp-not-published: ${{ steps.check_lsp_version.outputs.lsp-not-published }}
     steps:
       - uses: actions/checkout@v2
+       # serialize this workflow run
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
       - name: Install Dependencies
         run: npm install
       - name: Check for Update

--- a/.github/workflows/publish-insider-check-CLI.yml
+++ b/.github/workflows/publish-insider-check-CLI.yml
@@ -2,8 +2,8 @@ name: Insider Check for Update + Automated Publish
 
 on:
   schedule:
-   # the script takes about 12 minutes, so in order to not have two processes start together, this is set to 15
-    - cron: '*/15 * * * *'
+   # the script takes about 12-19 minutes, so in order to not have two processes start together, this is set to 20
+    - cron: '*/20 * * * *'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-insider-push-master.yml
+++ b/.github/workflows/publish-insider-push-master.yml
@@ -19,6 +19,9 @@ jobs:
       lsp-not-published: ${{ steps.check_lsp_version.outputs.lsp-not-published }}
     steps:
       - uses: actions/checkout@v2
+      # serialize this workflow run
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
       - name: Install Dependencies
         run: npm install
       - name: Bump versions

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -2,8 +2,8 @@ name: Stable Check for Minor Update + Automated Publish
 
 on:
   schedule:
-   # the script takes about 12 minutes, so in order to not have two processes start together, this is set to 15
-    - cron: '*/15 * * * *'
+   # the script takes about 12-19 minutes, so in order to not have two processes start together, this is set to 20
+    - cron: '*/20 * * * *'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When multiple workflows for publishing the Insider extension are running at the same time, one will fail. This PR uses https://github.com/marketplace/actions/action-turnstyle for two scripts to avoid that, by waiting for all other workflows to be finished before starting.

This also triggers CI tests only on pull_requests, since it is redundant otherwise.