### PR TITLE
chore: atomicNumberOperations and fix datasource previewFeatures flag

### DIFF
--- a/packages/language-server/src/completion/completionUtil.ts
+++ b/packages/language-server/src/completion/completionUtil.ts
@@ -141,8 +141,13 @@ export const generatorPreviewFeatures: CompletionItem[] = convertToCompletionIte
   CompletionItemKind.Constant,
 )
 
-export const generatorPreviewFeaturesArguments: CompletionItem[] = convertToCompletionItems(
-  completions.generatorPreviewFeaturesArguments,
+export const previewFeaturesArguments: CompletionItem[] = convertToCompletionItems(
+ completions.previewFeaturesArguments,
   CompletionItemKind.Property,
   (label: string) => label.replace('[]', '[$0]').replace('""', '"$0"'),
+)
+
+export const datasourcePreviewFeatures: CompletionItem[] = convertToCompletionItems(
+  completions.datasourcePreviewFeatures,
+  CompletionItemKind.Constant
 )

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -51,6 +51,10 @@
     {
       "label": "url",
       "documentation": "Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database, [learn more](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema)."
+    },
+    {
+      "label": "previewFeatures",
+      "documentation": "Enables preview feature flags."
     }
   ],
   "generatorFields": [
@@ -231,6 +235,12 @@
       "documentation": "Case insensitive scalar filters for supported DBs. Only postgres has any implementation at the moment, as SQLite doesn't reliably support insensitive filtering and MySQL is insensitive by default."
     },
     {
+      "label": "atomicNumberOperations",
+      "documentation": "Atomic updates for numeric operations. Check the [related issue](https://github.com/prisma/prisma-client-js/issues/775)."
+    }
+  ],
+  "datasourcePreviewFeatures": [
+    {
       "label": "nativeTypes",
       "documentation": "Allows to define custom types that should be used for a given field."
     }
@@ -271,7 +281,7 @@
       "documentation": "Specifies a single provider."
     }
   ],
-  "generatorPreviewFeaturesArguments": [
+  "previewFeaturesArguments": [
     {
       "label": "[]",
       "documentation": "Enables preview feature flags."

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -91,6 +91,10 @@ suite('Quick Fix', () => {
 
   // DATASOURCE BLOCK
 
+  const fieldPreviewFeatures = {
+    label: 'previewFeatures',
+    kind: CompletionItemKind.Field,
+  }
   const fieldProvider = {
     label: 'provider',
     kind: CompletionItemKind.Field,
@@ -119,7 +123,7 @@ suite('Quick Fix', () => {
       { line: 1, character: 0 },
       {
         isIncomplete: false,
-        items: [fieldProvider, fieldUrl],
+        items: [fieldProvider, fieldUrl, fieldPreviewFeatures],
       },
     )
   })
@@ -130,7 +134,7 @@ suite('Quick Fix', () => {
       { line: 2, character: 0 },
       {
         isIncomplete: false,
-        items: [fieldUrl],
+        items: [fieldUrl, fieldPreviewFeatures],
       },
     )
     await assertCompletion(
@@ -138,7 +142,7 @@ suite('Quick Fix', () => {
       { line: 2, character: 0 },
       {
         isIncomplete: false,
-        items: [fieldProvider],
+        items: [fieldProvider, fieldPreviewFeatures],
       },
     )
   })
@@ -213,10 +217,6 @@ suite('Quick Fix', () => {
   const fieldOutput = { label: 'output', kind: CompletionItemKind.Field }
   const fieldBinaryTargets = {
     label: 'binaryTargets',
-    kind: CompletionItemKind.Field,
-  }
-  const fieldPreviewFeatures = {
-    label: 'previewFeatures',
     kind: CompletionItemKind.Field,
   }
 

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -84,6 +84,10 @@ suite('Should auto-complete', () => {
 
   // DATASOURCE BLOCK
 
+  const fieldPreviewFeatures = {
+    label: 'previewFeatures',
+    kind: vscode.CompletionItemKind.Field,
+  }
   const fieldProvider = {
     label: 'provider',
     kind: vscode.CompletionItemKind.Field,
@@ -110,7 +114,11 @@ suite('Should auto-complete', () => {
     await testCompletion(
       emptyBlocksUri,
       new vscode.Position(1, 0),
-      new vscode.CompletionList([fieldProvider, fieldUrl]),
+      new vscode.CompletionList([
+        fieldProvider,
+        fieldUrl,
+        fieldPreviewFeatures,
+      ]),
       false,
     )
   })
@@ -119,13 +127,13 @@ suite('Should auto-complete', () => {
     await testCompletion(
       sqliteDocUri,
       new vscode.Position(2, 0),
-      new vscode.CompletionList([fieldUrl]),
+      new vscode.CompletionList([fieldUrl, fieldPreviewFeatures]),
       false,
     )
     await testCompletion(
       dataSourceWithUri,
       new vscode.Position(2, 0),
-      new vscode.CompletionList([fieldProvider]),
+      new vscode.CompletionList([fieldProvider, fieldPreviewFeatures]),
       false,
     )
   })
@@ -186,10 +194,6 @@ suite('Should auto-complete', () => {
   const fieldOutput = { label: 'output', kind: vscode.CompletionItemKind.Field }
   const fieldBinaryTargets = {
     label: 'binaryTargets',
-    kind: vscode.CompletionItemKind.Field,
-  }
-  const fieldPreviewFeatures = {
-    label: 'previewFeatures',
     kind: vscode.CompletionItemKind.Field,
   }
 


### PR DESCRIPTION
- fixes native types preview features to be shown for datasource block, not for generator block
- adds atomicNumberOperations feature flag to generator block