### PR TITLE
feat: quick fix for native types error message

### DIFF
--- a/packages/language-server/src/codeActionProvider.ts
+++ b/packages/language-server/src/codeActionProvider.ts
@@ -222,8 +222,20 @@ export function quickFix(
                 },
               },
             })
+          } else {
+            console.log(
+              'Not showing a quick-fix for native Types, because datasource block could not be found.',
+            )
           }
+        } else {
+          console.log(
+            'Not showing a quick-fix for native Types, because a datasource could not be found in cashed schema.',
+          )
         }
+      } else {
+        console.log(
+          'Not showing a quick-fix for native Types, because a datasource could not be found.',
+        )
       }
     }
     if (


### PR DESCRIPTION
closes #472 

Quick-fix adding `previewFeatures = ["nativeTypes"]` to the datasource block if using native Types in the schema but missing this field.