### PR TITLE
fix: quick-fix insert text for native types preview feature

### DIFF
--- a/packages/language-server/src/codeActionProvider.ts
+++ b/packages/language-server/src/codeActionProvider.ts
@@ -216,7 +216,7 @@ export function quickFix(
                           character: Number.MAX_VALUE,
                         },
                       },
-                      newText: '  previewFeatures = ["previewFeatures"]\n}',
+                      newText: '  previewFeatures = ["nativeTypes"]\n}',
                     },
                   ],
                 },


### PR DESCRIPTION
The quick-fix that mentions to add `previewFeatures = ["nativeTypes"]` actually inserts `previewFeatures = ["previewFeatures"]`