### PR TITLE
fix: path to project in eslint config since new version

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,6 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2020,
     sourceType: 'module',
-    project: ['./tsconfig.json', './packages/**/tsconfig.json'],
+    project: ['./tsconfig.json', './packages/vscode/tsconfig.json', 'packages/language-server/tsconfig.json'],
   }
 }


### PR DESCRIPTION
With the new version of `eslint`, it tries to find a `.tsconfig` in `node_modules`.  Specifying the exact path to the wanted `tsconfig.json` resolves that problem.