### PR TITLE
fix: regression of vsce

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -4792,9 +4792,9 @@
       "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "vsce": {
-      "version": "1.81.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.81.0.tgz",
-      "integrity": "sha512-ZK8YBGww8FCYTgHAzPZ/iIEJrm12vJWkKNRL25MRxfUlqRIjpQ0S3HejcMpSfYp0/Ghm/QpWnP/ld2KvGvneRA==",
+      "version": "1.80.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.80.0.tgz",
+      "integrity": "sha512-pnJT0LttCd5k1fJRsTOer8NvgesMYxLZYTUwuVWVOgONK9w+U5Yf32rtm4cX374TsHZbBwUr6ZFLP36wyDD8/g==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^7.2.0",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -92,7 +92,7 @@
   "devDependencies": {
     "@types/glob": "7.1.3",
     "@types/vscode": "1.49.0",
-    "vsce": "1.81.0",
+    "vsce": "1.80.0",
     "vscode-test": "1.4.0",
     "@types/mocha": "8.0.3",
     "mocha": "8.1.3",

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "semanticCommits": true,
-  "ignoreDeps": ["@prisma/language-server", "@prisma/get-platform"],
+  "ignoreDeps": ["@prisma/language-server", "@prisma/get-platform", "vsce"],
   "masterIssue": true,
   "reviewers": ["@divyenduz", "@carmenberndt"],
   "rebaseWhen": "conflicted",


### PR DESCRIPTION
regression of `vsce` from version `1.81.0`, therefore pinning version `1.80.0`.
This led to the `node_modules` folder not being included on `vsce package`