### PR TITLE
build: remove types/vscode dep from renovate

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -82,9 +82,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.50.0.tgz",
-      "integrity": "sha512-QnIeyi4L2DiD9M2bAQKRzT/EQvc80qP9UL6JD5TiLlNRL1khIDg4ej4mDSRbtFrDAsRntFI1RhMvdomUThMsqg==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.49.0.tgz",
+      "integrity": "sha512-wfNQmLmm1VdMBr6iuNdprWmC1YdrgZ9dQzadv+l2eSjJlElOdJw8OTm4RU4oGTBcfvG6RZI2jOcppkdSS18mZw==",
       "dev": true
     },
     "agent-base": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -91,7 +91,7 @@
   },
   "devDependencies": {
     "@types/glob": "7.1.3",
-    "@types/vscode": "1.50.0",
+    "@types/vscode": "1.49.0",
     "vsce": "1.81.1",
     "vscode-test": "1.4.0",
     "@types/mocha": "8.0.3",

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "semanticCommits": true,
-  "ignoreDeps": ["@prisma/language-server", "@prisma/get-platform"],
+  "ignoreDeps": ["@prisma/language-server", "@prisma/get-platform, @types/vscode", "vscode"],
   "masterIssue": true,
   "reviewers": ["@divyenduz", "@carmenberndt"],
   "rebaseWhen": "conflicted",

--- a/renovate.json
+++ b/renovate.json
@@ -3,11 +3,16 @@
     "config:base"
   ],
   "semanticCommits": true,
-  "ignoreDeps": ["@prisma/language-server", "@prisma/get-platform, @types/vscode", "vscode"],
+  "ignoreDeps": ["@prisma/language-server", "@prisma/get-platform"],
   "masterIssue": true,
   "reviewers": ["@divyenduz", "@carmenberndt"],
   "rebaseWhen": "conflicted",
   "packageRules": [
+    {
+      "groupName": "VSCode",
+      "packageNames": ["vscode", "@types/vscode"],
+      "updateTypes": ["patch", "minor"]
+    },
     {
       "groupName": "checkpoint-client",
       "packageNames": ["checkpoint-client"],
@@ -24,6 +29,7 @@
       "groupName": "definitelyTyped",
       "automerge": "true",
       "packagePatterns": ["^@types/"],
+      "excludePackageNames": ["@types/vscode"],
       "updateTypes": ["patch", "minor"]
     },
     {


### PR DESCRIPTION
- downgrades `@types/vscode` from `1.50.0` to `1.49.0`
- excludes `vscode` and `@types/vscode` from renovate bot config

Why:
- `@types/vscode` must not have a higher version than the engine `vscode`