### PR TITLE
fix: exclude comments from default suggestions

### DIFF
--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -793,7 +793,7 @@ function getFieldsFromCurrentBlock(
     }
     if (!item.startsWith('@@') && (!position || key !== position.line)) {
       field = item.replace(/ .*/, '')
-      if (field !== '') {
+      if (field !== '' && !field.startsWith('//')) {
         suggestions.push(field)
       }
     }

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -62,6 +62,7 @@ suite('Quick Fix', () => {
   const dataSourceWithUri = 'completions/datasourceWithUrl.prisma'
   const emptyBlocksUri = 'completions/emptyBlocks.prisma'
   const modelBlocksUri = 'completions/modelBlocks.prisma'
+  const enumCommentUri = 'completions/enumWithComments.prisma'
 
   // ALL BLOCKS
 
@@ -528,6 +529,17 @@ suite('Quick Fix', () => {
     assertCompletion(
       modelBlocksUri,
       { line: 62, character: 27 },
+      {
+        isIncomplete: false,
+        items: [enumValueOne, enumValueTwo],
+      },
+    )
+  })
+
+  test('Diagnoses default suggestions for enum values excluding comments', () => {
+    assertCompletion(
+      enumCommentUri,
+      { line: 11, character: 30 },
       {
         isIncomplete: false,
         items: [enumValueOne, enumValueTwo],

--- a/packages/language-server/test/fixtures/completions/enumWithComments.prisma
+++ b/packages/language-server/test/fixtures/completions/enumWithComments.prisma
@@ -1,0 +1,20 @@
+datasource db {
+    provider = "mysql"
+    url = "mysql://"
+}
+
+generator client {
+    provider = "prisma-client-js"
+}
+
+model Test {
+    id Int @id
+    enum CommentEnum @default()
+}
+
+enum CommentEnum {
+    // Comment
+    ADMIN
+    NORMAL
+    /// Doc comment
+}

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -489,8 +489,8 @@ suite('Should auto-complete', () => {
       enumCommentUri,
       new vscode.Position(11, 30),
       new vscode.CompletionList([
-        { label: 'ADMIN', kind: vscode.CompletionItemKind.Constant },
-        { label: 'NORMAL', kind: vscode.CompletionItemKind.Constant },
+        { label: 'ADMIN', kind: vscode.CompletionItemKind.Value },
+        { label: 'NORMAL', kind: vscode.CompletionItemKind.Value },
       ]),
 
       false,

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -46,6 +46,7 @@ suite('Should auto-complete', () => {
   const dataSourceWithUri = getDocUri('completions/datasourceWithUrl.prisma')
   const emptyBlocksUri = getDocUri('completions/emptyBlocks.prisma')
   const modelBlocksUri = getDocUri('completions/modelBlocks.prisma')
+  const enumCommentUri = getDocUri('completions/enumWithComments.prisma')
 
   // ALL BLOCKS
 
@@ -480,6 +481,19 @@ suite('Should auto-complete', () => {
         { label: 'lastName', kind: vscode.CompletionItemKind.Field },
       ]),
       true,
+    )
+  })
+
+  test('Diagnoses default suggestions for enum values excluding comments', async () => {
+    await testCompletion(
+      enumCommentUri,
+      new vscode.Position(11, 30),
+      new vscode.CompletionList([
+        { label: 'ADMIN', kind: vscode.CompletionItemKind.Constant },
+        { label: 'NORMAL', kind: vscode.CompletionItemKind.Constant },
+      ]),
+
+      false,
     )
   })
 

--- a/packages/vscode/testFixture/completions/enumWithComments.prisma
+++ b/packages/vscode/testFixture/completions/enumWithComments.prisma
@@ -1,0 +1,20 @@
+datasource db {
+    provider = "mysql"
+    url = "mysql://"
+}
+
+generator client {
+    provider = "prisma-client-js"
+}
+
+model Test {
+    id Int @id
+    enum CommentEnum @default()
+}
+
+enum CommentEnum {
+    // Comment
+    ADMIN
+    NORMAL
+    /// Doc comment
+}


### PR DESCRIPTION
fixes #547 