### PR TITLE
fix: tolerate null configuration

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -146,10 +146,12 @@ export function startServer(options?: LSPOptions): void {
     }
     let result = documentSettings.get(resource)
     if (!result) {
-      result = connection.workspace.getConfiguration({
-        scopeUri: resource,
-        section: 'prismaLanguageServer',
-      })
+      result = connection.workspace
+        .getConfiguration({
+          scopeUri: resource,
+          section: 'prismaLanguageServer',
+        })
+        .then((settings) => settings || globalSettings)
       documentSettings.set(resource, result)
     }
     return result


### PR DESCRIPTION

> If the client can’t provide a configuration setting for a given scope then null needs to be present in the returned array.
>
> source: https://microsoft.github.io/language-server-protocol/specification#workspace_configuration
