### PR TITLE
fix: rename with cursor on first/middle position of the word

### DIFF
--- a/packages/language-server/src/rename/renameUtil.ts
+++ b/packages/language-server/src/rename/renameUtil.ts
@@ -534,7 +534,11 @@ export function extractCurrentName(
   if (isModelOrEnumRename) {
     const currentLineUntrimmed = getCurrentLine(document, position.line)
     const currentLineTillPosition = currentLineUntrimmed
-      .slice(0, position.character)
+      .slice(
+        0,
+        position.character +
+          currentLineUntrimmed.slice(position.character).search(/\W/),
+      )
       .trim()
     const wordsBeforePosition: string[] = currentLineTillPosition.split(/\s+/)
     if (wordsBeforePosition.length < 2) {

--- a/packages/language-server/src/test/rename.test.ts
+++ b/packages/language-server/src/test/rename.test.ts
@@ -92,6 +92,102 @@ suite('Rename', () => {
         changes: {
           [renameModel.uri]: [
             {
+              newText: newModelName,
+              range: {
+                start: { line: 17, character: 6 },
+                end: { line: 17, character: 10 },
+              },
+            },
+            {
+              newText: '\t@@map("User")\n}',
+              range: {
+                start: { line: 23, character: 0 },
+                end: { line: 23, character: 1 },
+              },
+            },
+            {
+              newText: newModelName,
+              range: {
+                start: { line: 13, character: 12 },
+                end: { line: 13, character: 16 },
+              },
+            },
+          ],
+        },
+      },
+      renameModel,
+      newModelName,
+      { line: 17, character: 9 },
+    )
+    assertRename(
+      {
+        changes: {
+          [renameModel.uri]: [
+            {
+              newText: newModelName,
+              range: {
+                start: { line: 17, character: 6 },
+                end: { line: 17, character: 10 },
+              },
+            },
+            {
+              newText: '\t@@map("User")\n}',
+              range: {
+                start: { line: 23, character: 0 },
+                end: { line: 23, character: 1 },
+              },
+            },
+            {
+              newText: newModelName,
+              range: {
+                start: { line: 13, character: 12 },
+                end: { line: 13, character: 16 },
+              },
+            },
+          ],
+        },
+      },
+      renameModel,
+      newModelName,
+      { line: 17, character: 8 },
+    )
+    assertRename(
+      {
+        changes: {
+          [renameModel.uri]: [
+            {
+              newText: newModelName,
+              range: {
+                start: { line: 17, character: 6 },
+                end: { line: 17, character: 10 },
+              },
+            },
+            {
+              newText: '\t@@map("User")\n}',
+              range: {
+                start: { line: 23, character: 0 },
+                end: { line: 23, character: 1 },
+              },
+            },
+            {
+              newText: newModelName,
+              range: {
+                start: { line: 13, character: 12 },
+                end: { line: 13, character: 16 },
+              },
+            },
+          ],
+        },
+      },
+      renameModel,
+      newModelName,
+      { line: 17, character: 6 },
+    )
+    assertRename(
+      {
+        changes: {
+          [renameModel.uri]: [
+            {
               newText: newModelName2,
               range: {
                 start: { line: 9, character: 6 },


### PR DESCRIPTION
closes https://github.com/prisma/language-tools/issues/576