### PR TITLE
feat: optimize for downloading failure

### DIFF
--- a/packages/language-server/src/prisma-fmt/install.ts
+++ b/packages/language-server/src/prisma-fmt/install.ts
@@ -2,7 +2,6 @@
  * Imports
  */
 
-import * as util from './../util'
 import https from 'https'
 import zlib from 'zlib'
 import fs from 'fs'
@@ -11,8 +10,10 @@ import fs from 'fs'
  * Install prisma format
  */
 
-export default async function install(fmtPath: string): Promise<string> {
-  const url = await util.getDownloadURL()
+export default async function install(
+  url: string,
+  fmtPath: string,
+): Promise<string> {
   const file = fs.createWriteStream(fmtPath)
 
   // Fetch fetch fetch.

--- a/packages/language-server/src/prisma-fmt/install.ts
+++ b/packages/language-server/src/prisma-fmt/install.ts
@@ -17,11 +17,11 @@ export default async function install(fmtPath: string): Promise<string> {
 
   // Fetch fetch fetch.
   try {
-    return new Promise<string>(function (resolve, reject) {
+    return await new Promise<string>(function (resolve, reject) {
       https.get(url, function (response) {
         // Did everything go well?
         if (response.statusCode !== 200) {
-          reject(response.statusMessage)
+          reject(new Error(response.statusMessage))
         }
 
         // If so, unzip and pipe into our file.

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -8,7 +8,7 @@ import {
 } from 'vscode-languageserver'
 import * as assert from 'assert'
 import { getTextDocument } from './helper'
-import { getBinPath, binaryIsNeeded } from '../util'
+import { getBinPath, binaryIsNeeded, getDownloadURL } from '../util'
 import install from '../prisma-fmt/install'
 
 function assertCompletion(
@@ -54,7 +54,9 @@ suite('Quick Fix', () => {
     if (binPathPrismaFmt === '') {
       binPathPrismaFmt = await getBinPath()
     }
-    if (binaryIsNeeded(binPathPrismaFmt)) await install(binPathPrismaFmt)
+    if (binaryIsNeeded(binPathPrismaFmt)) {
+      await install(await getDownloadURL(), binPathPrismaFmt)
+    }
   })
 
   const emptyDocUri = 'completions/empty.prisma'

--- a/packages/language-server/src/test/format.test.ts
+++ b/packages/language-server/src/test/format.test.ts
@@ -1,6 +1,6 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { handleDocumentFormatting } from '../MessageHandler'
-import { getBinPath, binaryIsNeeded } from '../util'
+import { getBinPath, binaryIsNeeded, getDownloadURL } from '../util'
 import install from '../prisma-fmt/install'
 import { TextEdit, DocumentFormattingParams } from 'vscode-languageserver'
 import * as assert from 'assert'
@@ -36,7 +36,8 @@ suite('Format', () => {
     if (binPathPrismaFmt === '') {
       binPathPrismaFmt = await getBinPath()
     }
-    if (binaryIsNeeded(binPathPrismaFmt)) await install(binPathPrismaFmt)
+    if (binaryIsNeeded(binPathPrismaFmt))
+      await install(await getDownloadURL(), binPathPrismaFmt)
   })
 
   const fixturePath = './formatting/autoFormat.prisma'

--- a/packages/language-server/src/test/linting.test.ts
+++ b/packages/language-server/src/test/linting.test.ts
@@ -1,6 +1,6 @@
 import { TextDocument } from 'vscode-languageserver-textdocument'
 import { handleDiagnosticsRequest } from '../MessageHandler'
-import { getBinPath, binaryIsNeeded } from '../util'
+import { getBinPath, binaryIsNeeded, getDownloadURL } from '../util'
 import install from '../prisma-fmt/install'
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver'
 import * as assert from 'assert'
@@ -35,7 +35,9 @@ suite('Linting', () => {
     if (binPathPrismaFmt === '') {
       binPathPrismaFmt = await getBinPath()
     }
-    if (binaryIsNeeded(binPathPrismaFmt)) await install(binPathPrismaFmt)
+    if (binaryIsNeeded(binPathPrismaFmt)) {
+      await install(await getDownloadURL(), binPathPrismaFmt)
+    }
   })
 
   const fixturePathMissingArgument = './linting/missingArgument.prisma'


### PR DESCRIPTION
At this time, a failed downloading of `prisma-fmt` will result in language server closing with no output, which is difficult to look into. 

- [x] Catch errors and cleanup temporary file
- [x] Provide instrument on alternative downloading method (e.g. manual download)
