### PR TITLE
chore(native-types): move native types to generator block

### DIFF
--- a/packages/language-server/src/codeActionProvider.ts
+++ b/packages/language-server/src/codeActionProvider.ts
@@ -193,16 +193,16 @@ export function quickFix(
       diag.message.includes('previewFeatures = ["nativeTypes"]')
     ) {
       // get datasource block
-      const datasourceStart = lines.filter(
-        (l) => l.startsWith('datasource') && l.includes('{'),
+      const generatorStart = lines.filter(
+        (l) => l.startsWith('generator') && l.includes('{'),
       )
-      if (datasourceStart.length !== 0) {
-        const index = lines.indexOf(datasourceStart[0])
+      if (generatorStart.length !== 0) {
+        const index = lines.indexOf(generatorStart[0])
         if (index !== -1) {
           const block = getBlockAtPosition(index, lines)
           if (block) {
             codeActions.push({
-              title: "Add preview feature 'nativeTypes' to datasource block.",
+              title: "Add preview feature 'nativeTypes' to generator block.",
               kind: CodeActionKind.QuickFix,
               diagnostics: [diag],
               edit: {
@@ -224,17 +224,17 @@ export function quickFix(
             })
           } else {
             console.log(
-              'Not showing a quick-fix for native Types, because datasource block could not be found.',
+              'Not showing a quick-fix for native Types, because generator block could not be found.',
             )
           }
         } else {
           console.log(
-            'Not showing a quick-fix for native Types, because a datasource could not be found in cashed schema.',
+            'Not showing a quick-fix for native Types, because a generator could not be found in cashed schema.',
           )
         }
       } else {
         console.log(
-          'Not showing a quick-fix for native Types, because a datasource could not be found.',
+          'Not showing a quick-fix for native Types, because a generator could not be found.',
         )
       }
     }

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -51,10 +51,6 @@
     {
       "label": "url",
       "documentation": "Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database, [learn more](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-schema)."
-    },
-    {
-      "label": "previewFeatures",
-      "documentation": "Enables preview feature flags."
     }
   ],
   "generatorFields": [

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -648,16 +648,8 @@ export function getSuggestionForSupportedFields(
             items: dataSourceUrlArguments,
             isIncomplete: true,
           }
-        } // TODO: uncomment once nativeTypes will be launched!
-      } /*else if (currentLine.startsWith('previewFeatures')) {
-        const datasourcePreviewFeatures: string[] = previewFeatures(binPath, true)
-        return handlePreviewFeatures(
-          datasourcePreviewFeatures,
-          position,
-          currentLineUntrimmed,
-          isInsideQuotation,
-        )
-      } */
+        }
+      }
       break
   }
 


### PR DESCRIPTION
- removes preview features from datasource block
- adjusts quick fix for adding native types flag to generator block