### PR TITLE
feat(types): add new scalar types to auto-completion

### DIFF
--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -23,6 +23,14 @@
     {
       "label": "Json",
       "documentation": "A JSON object"
+    },
+    {
+      "label": "Bytes",
+      "documentation": ""
+    },
+    {
+      "label": "Decimal",
+      "documentation": "Decimal value"
     }
   ],
   "blockTypes": [

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -342,6 +342,8 @@ suite('Quick Fix', () => {
           { label: 'Float', kind: CompletionItemKind.TypeParameter },
           { label: 'DateTime', kind: CompletionItemKind.TypeParameter },
           { label: 'Json', kind: CompletionItemKind.TypeParameter },
+          { label: 'Bytes', kind: CompletionItemKind.TypeParameter },
+          { label: 'Decimal', kind: CompletionItemKind.TypeParameter },
           { label: 'User', kind: CompletionItemKind.Reference },
           { label: 'Post', kind: CompletionItemKind.Reference },
           { label: 'Person', kind: CompletionItemKind.Reference },

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -316,6 +316,8 @@ suite('Should auto-complete', () => {
           { label: 'Post', kind: vscode.CompletionItemKind.Reference },
           { label: 'SecondUser', kind: vscode.CompletionItemKind.Reference },
           { label: 'String', kind: vscode.CompletionItemKind.TypeParameter },
+          { label: 'Bytes', kind: vscode.CompletionItemKind.TypeParameter },
+          { label: 'Decimal', kind: vscode.CompletionItemKind.TypeParameter },
           { label: 'Test', kind: vscode.CompletionItemKind.Reference },
           { label: 'ThirdUser', kind: vscode.CompletionItemKind.Reference },
           { label: 'TypeCheck', kind: vscode.CompletionItemKind.Reference },


### PR DESCRIPTION
adds `Bytes` and `Decimal` Prisma types