### PR TITLE
feat(syntax): display scalar prisma types differently than relations …

### DIFF
--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -143,9 +143,10 @@
       ]
     },
     "field_definition": {
+      "name": "scalar.field",
       "patterns": [
         {
-          "match": "^\\s*(\\w+)(\\s*:)?\\s+(\\w+)(\\[\\])?(\\?)?(\\!)?",
+          "match": "^\\s*(\\w+)(\\s*:)?\\s+(Int|String|DateTime|Bytes|Decimal|Boolean)?(\\w+)?(\\[\\])?(\\?)?(\\!)?",
           "captures": {
             "1": {
               "name": "variable.other.assignment.prisma"
@@ -157,12 +158,15 @@
               "name": "support.type.primitive.prisma"
             },
             "4": {
-              "name": "keyword.operator.list_type.prisma"
+              "name": "variable.language.relations.prisma"
             },
             "5": {
-              "name": "keyword.operator.optional_type.prisma"
+              "name": "keyword.operator.list_type.prisma"
             },
             "6": {
+              "name": "keyword.operator.optional_type.prisma"
+            },
+            "7": {
               "name": "invalid.illegal.required_type.prisma"
             }
           }


### PR DESCRIPTION
![Screenshot 2020-11-12 at 15 02 56](https://user-images.githubusercontent.com/30771368/98965541-76ebd600-250a-11eb-94d6-703b428ff47c.png)
closes https://github.com/prisma/language-tools/issues/41

Syntax highlighting uses a TextMate grammar containing scopes (https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#textmate-grammars).
Common scopes, so ones that are being used by most themes, are described here: https://macromates.com/manual/en/language_grammars
In the last link under 12.4 the naming conventions are also listed. Most of them are already used for something else in our TextMate grammar, and also some are not supported by the default VSCode themes Default Dark+ and Default Light+. I tried out the ones we were not using yet and found `variable.language` to be free and make a difference in colour.