### PR TITLE
chore(logging): add logging option to VSCode settings

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -128,9 +128,7 @@ export function startServer(options?: LSPOptions): void {
       // Reset all cached document settings
       documentSettings.clear()
     } else {
-      globalSettings = <LSPSettings>(
-        (change.settings.prismaLanguageServer || defaultSettings) // eslint-disable-line @typescript-eslint/no-unsafe-member-access
-      )
+      globalSettings = <LSPSettings>(change.settings.prisma || defaultSettings) // eslint-disable-line @typescript-eslint/no-unsafe-member-access
     }
     documents.all().forEach(async (d) => await installPrismaFmt(d.uri)) // eslint-disable-line @typescript-eslint/no-misused-promises
 
@@ -152,7 +150,7 @@ export function startServer(options?: LSPOptions): void {
     if (!result) {
       result = connection.workspace.getConfiguration({
         scopeUri: resource,
-        section: 'prismaLanguageServer',
+        section: 'prisma',
       })
       documentSettings.set(resource, result)
     }
@@ -222,7 +220,7 @@ export function startServer(options?: LSPOptions): void {
         connection.console.error(
           `Cannot install prisma-fmt: ${message}. Please:\n` +
             '1. Check your network connection and run `Prisma: Restart Language Server`, or\n' +
-            '2. Manually download and uncompress the archive file, then set the path in `prismaLanguageServer.prismaFmtBinPath`\n\n' +
+            '2. Manually download and uncompress the archive file, then set the path in `prisma.prismaFmtBinPath`\n\n' +
             `The achieve file can be acquired at:\n  ${downloadUrl}\n\n`,
         )
       }

--- a/packages/vscode/CONTRIBUTING.md
+++ b/packages/vscode/CONTRIBUTING.md
@@ -43,7 +43,7 @@ On push to the master branch, a new Insider extension is released, with an incre
 
 ## Debugging
 
-- Set `prismaLanguageServer.trace.server` to `messages` or `verbose` to trace the communication between VSCode and the language server.
+- Set `prisma.trace.server` to `messages` or `verbose` to trace the communication between VSCode and the language server.
 - There is a tool to visualize and filter the communication between Language Client / Server. All logs from the channel can be saved into a file, and loaded with the Language Server Protocol Inspector at https://microsoft.github.io/language-server-protocol/inspector
 
 ## Testing

--- a/packages/vscode/CONTRIBUTING.md
+++ b/packages/vscode/CONTRIBUTING.md
@@ -41,6 +41,11 @@ On push to the master branch, a new Insider extension is released, with an incre
 - Make a change to the syntax
 - To reload, press the reload button in VSCode ( **Developer: Inspect TM Scopes** is helpful for debugging syntax issues )
 
+## Debugging
+
+- Set `prismaLanguageServer.trace.server` to `messages` or `verbose` to trace the communication between VSCode and the language server.
+- There is a tool to visualize and filter the communication between Language Client / Server. All logs from the channel can be saved into a file, and loaded with the Language Server Protocol Inspector at https://microsoft.github.io/language-server-protocol/inspector
+
 ## Testing
 
 Instructions on manual testing can be found [here](TESTING.md).

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -80,6 +80,17 @@
           "scope": "resource",
           "type": "string",
           "description": "Option to set the path to the prisma-fmt binary."
+        },
+        "prismaLanguageServer.trace.server": {
+          "scope": "window",
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the language server."
         }
       }
     },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -76,12 +76,12 @@
       "type": "object",
       "title": "Language server configuration",
       "properties": {
-        "prismaLanguageServer.prismaFmtBinPath": {
+        "prisma.prismaFmtBinPath": {
           "scope": "resource",
           "type": "string",
           "description": "Option to set the path to the prisma-fmt binary."
         },
-        "prismaLanguageServer.trace.server": {
+        "prisma.trace.server": {
           "scope": "window",
           "type": "string",
           "enum": [


### PR DESCRIPTION
With the setting `prisma.trace.server` the communication between VSCode and the language server can get traced. The default setting is `off`. Options are `messages` and `verbose`. When heading to `Prisma Language Server` output, the logs will be available if turned on.

As Language Servers can be chatty (5 seconds of real-world usage can produce 5000 lines of log), there is a tool to visualize and filter the communication between Language Client / Server. All logs from the channel can be saved into a file, and loaded with the Language Server Protocol Inspector at https://microsoft.github.io/language-server-protocol/inspector

- [x] add note to `CONTRIBUTING.md`

closes #627 