### PR TITLE
fix: missing scalar types in syntax highlighting

### DIFF
--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -146,7 +146,7 @@
       "name": "scalar.field",
       "patterns": [
         {
-          "match": "^\\s*(\\w+)(\\s*:)?\\s+(Int|String|DateTime|Bytes|Decimal|Boolean)?(\\w+)?(\\[\\])?(\\?)?(\\!)?",
+          "match": "^\\s*(\\w+)(\\s*:)?\\s+(Int|String|DateTime|Bytes|Decimal|Float|Json|Boolean)?(\\w+)?(\\[\\])?(\\?)?(\\!)?",
           "captures": {
             "1": {
               "name": "variable.other.assignment.prisma"


### PR DESCRIPTION
closes https://github.com/prisma/language-tools/issues/638