### PR TITLE
fix: do not followSymlinks when watching for file changes

### DIFF
--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -30,7 +30,6 @@ import {
   isSnippetEdit,
 } from '../../util'
 import { PrismaVSCodePlugin } from '../types'
-import * as picomatch from 'picomatch'
 
 const packageJson = require('../../../../package.json') // eslint-disable-line
 

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -30,6 +30,7 @@ import {
   isSnippetEdit,
 } from '../../util'
 import { PrismaVSCodePlugin } from '../types'
+import * as picomatch from 'picomatch'
 
 const packageJson = require('../../../../package.json') // eslint-disable-line
 
@@ -65,6 +66,7 @@ const plugin: PrismaVSCodePlugin = {
         path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
         {
           usePolling: false,
+          followSymlinks: false,
         },
       )
     }


### PR DESCRIPTION
fixes #604 

In yarn workspaces packages are symlinked, so chokidar ends up watching all file changes. Setting `followSymlinks: false`, only the symlinks themselves will be watched for changes instead of following the link references and bubbling events through the link's path.