### PR TITLE
feat(lang-server): Recognize BigInt as a Prisma type

### DIFF
--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -33,13 +33,17 @@
       "documentation": "Decimal value"
     },
     {
+      "label": "BigInt",
+      "documentation": "Integer values that may be greater than 2^53"
+    },
+    {
       "label": "Unsupported(\"\")",
       "documentation": "An arbitrary database column type, for which Prisma has no syntax. Fields of type `Unsupported` work with Prisma Migrate and introspection, but are not exposed in Prisma Client.",
       "fullSignature": "Unsupported(_ name: String)",
       "params": [
         {
           "label": "name",
-          "documentation": "Name of the column type as expected by the underlying database, e.g. Unsupported(\"GEOGRAPHY(POINT,4326)\"). This string is not validated by Prisma Migrate and will be used by Prisma Migrate to generate the DDL statements to evolve the database schema. Prisma Introspect will overwrite this when re-introspecting if the type does not match." 
+          "documentation": "Name of the column type as expected by the underlying database, e.g. Unsupported(\"GEOGRAPHY(POINT,4326)\"). This string is not validated by Prisma Migrate and will be used by Prisma Migrate to generate the DDL statements to evolve the database schema. Prisma Introspect will overwrite this when re-introspecting if the type does not match."
         }
       ]
     }

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -359,6 +359,7 @@ suite('Quick Fix', () => {
           { label: 'Json', kind: CompletionItemKind.TypeParameter },
           { label: 'Bytes', kind: CompletionItemKind.TypeParameter },
           { label: 'Decimal', kind: CompletionItemKind.TypeParameter },
+          { label: 'BigInt', kind: CompletionItemKind.TypeParameter },
           { label: 'Unsupported("")', kind: CompletionItemKind.TypeParameter },
           { label: 'User', kind: CompletionItemKind.Reference },
           { label: 'Post', kind: CompletionItemKind.Reference },

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -326,6 +326,7 @@ suite('Should auto-complete', () => {
           { label: 'String', kind: vscode.CompletionItemKind.TypeParameter },
           { label: 'Bytes', kind: vscode.CompletionItemKind.TypeParameter },
           { label: 'Decimal', kind: vscode.CompletionItemKind.TypeParameter },
+          { label: 'BigInt', kind: vscode.CompletionItemKind.TypeParameter },
           {
             label: 'Unsupported("")',
             kind: vscode.CompletionItemKind.TypeParameter,


### PR DESCRIPTION
Noticed that `Bytes` and `Decimal` were recognized as Prisma types, but not BigInt. Although these 3 are only really valid with `nativeTypes`, this should be okay since native types are going to be GA soon.