### PR TITLE
fix: check for binary setting existence 

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -158,7 +158,7 @@ export function startServer(options?: LSPOptions): void {
   }
 
   function getPrismaFmtBinPath(binPathSetting: string | undefined): string {
-    if (!binPathSetting) {
+    if (!binPathSetting || binPathSetting.length === 0) {
       return defaultBinPath
     } else if (!existsSync(binPathSetting)) {
       connection.window.showErrorMessage(

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -157,8 +157,8 @@ export function startServer(options?: LSPOptions): void {
     return result
   }
 
-  function getPrismaFmtBinPath(binPathSetting: string): string {
-    if (binPathSetting.length === 0) {
+  function getPrismaFmtBinPath(binPathSetting: string | undefined): string {
+    if (!binPathSetting) {
       return defaultBinPath
     } else if (!existsSync(binPathSetting)) {
       connection.window.showErrorMessage(


### PR DESCRIPTION
This was crashing the neovim extension. The binary path we receive from setting can be null if that doesn't exists. This PR introduces a null check for that. 

Thanks!