### PR TITLE
feat: introduce explicit allow prompts for custom binaries

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -102,12 +102,12 @@
       },
       {
         "command": "prisma.resetCurrentFmtBinDecision",
-        "title": "Reset current Prisma fmt binary execution decision",
+        "title": "Reset current Prisma format binary execution decision",
         "category": "Prisma"
       },
       {
         "command": "prisma.resetAllBinDecisions",
-        "title": "Reset all Prisma fmt binary execution decisions",
+        "title": "Reset all Prisma format binary execution decisions",
         "category": "Prisma"
       }
     ]

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -99,6 +99,11 @@
         "command": "prisma.restartLanguageServer",
         "title": "Restart Language Server",
         "category": "Prisma"
+      },
+      {
+        "command": "prisma.resetBinDecisions",
+        "title": "Reset Binary execution decisions",
+        "category": "Prisma"
       }
     ]
   },

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -101,8 +101,13 @@
         "category": "Prisma"
       },
       {
-        "command": "prisma.resetBinDecisions",
-        "title": "Reset Binary execution decisions",
+        "command": "prisma.resetCurrentFmtBinDecision",
+        "title": "Reset current Prisma fmt binary execution decision",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.resetAllBinDecisions",
+        "title": "Reset all Prisma fmt binary execution decisions",
         "category": "Prisma"
       }
     ]

--- a/packages/vscode/src/binaryValidator.ts
+++ b/packages/vscode/src/binaryValidator.ts
@@ -55,6 +55,6 @@ export const checkAndAskForBinaryExecution = async (
 
 export const printBinaryCheckWarning = async () => {
   await window.showWarningMessage(
-    "Execution of Prisma extension's binary defined in settings was not allowed. Please either change the binary path or reset the approval by opening the VS Code command palette and search for 'Reset Binary execution decisions', then press Enter.",
+    "Execution of Prisma extension's binary defined in settings was not allowed. Please either change the binary path or reset the approval by opening the VS Code command palette and search for 'Reset current Prisma format binary execution decision', then press Enter.",
   )
 }

--- a/packages/vscode/src/binaryValidator.ts
+++ b/packages/vscode/src/binaryValidator.ts
@@ -59,6 +59,6 @@ export const checkAndAskForBinaryExecution = async (
 
 export const printBinaryCheckWarning = async () => {
   await window.showWarningMessage(
-    "Prisma extension hasn't got the approval for usage for binary defined in settings. Please either change the binary path or reset library execution decisions.",
+    "Prisma extension's binary defined in settings was not approved. Please either change the binary path or reset the approval by opening the VS Code command palette and search for 'Reset Binary execution decisions', then press Enter.",
   )
 }

--- a/packages/vscode/src/binaryValidator.ts
+++ b/packages/vscode/src/binaryValidator.ts
@@ -43,10 +43,6 @@ export const checkAndAskForBinaryExecution = async (
       result = true
     }
 
-    if (item.value === BinaryPopupStatus.Deny) {
-      result = false
-    }
-
     // store the state
     bins = bins ? bins : { libs: {} }
     bins.libs[binaryPath] = { allowed: result }

--- a/packages/vscode/src/binaryValidator.ts
+++ b/packages/vscode/src/binaryValidator.ts
@@ -25,7 +25,7 @@ export const checkAndAskForBinaryExecution = async (
   const existingBinaryState = bins?.libs[binaryPath]
   if (!existingBinaryState) {
     const item = await window.showInformationMessage(
-      `Your VSCode workspace is defining a custom binary path for the Prisma extension:"${binaryPath}" . Do you want to trust this binary and let the extension execute it?`,
+      `Your VS Code workspace is defining a custom binary path for the Prisma extension: "${binaryPath}" Do you want to trust this binary and let the extension execute it?`,
       {
         modal: true,
       },

--- a/packages/vscode/src/binaryValidator.ts
+++ b/packages/vscode/src/binaryValidator.ts
@@ -25,7 +25,7 @@ export const checkAndAskForBinaryExecution = async (
   const existingBinaryState = bins?.libs[binaryPath]
   if (!existingBinaryState) {
     const item = await window.showInformationMessage(
-      `Your VS Code workspace is defining a custom binary path for the Prisma extension: "${binaryPath}" Do you want to trust this binary and let the extension execute it?`,
+      `Your VS Code workspace is defining a custom binary path for the Prisma extension: '${binaryPath}'. Do you trust this binary and allow the extension to execute it?`,
       {
         modal: true,
       },

--- a/packages/vscode/src/binaryValidator.ts
+++ b/packages/vscode/src/binaryValidator.ts
@@ -1,0 +1,64 @@
+import { ExtensionContext, window } from 'vscode'
+
+export const PRISMA_ALLOWED_BINS_KEY = 'prismaAllowedBins'
+
+export type BinaryState = {
+  allowed: boolean
+}
+
+export enum BinaryPopupStatus {
+  Allow,
+  Deny,
+}
+
+export type BinaryStorage = { libs: { [key: string]: BinaryState } }
+
+export const checkAndAskForBinaryExecution = async (
+  context: ExtensionContext,
+  binaryPath: string | undefined,
+  bins: BinaryStorage | undefined,
+): Promise<boolean> => {
+  // empty binary path means we are using the default binary
+  if (!binaryPath || binaryPath === '') {
+    return true
+  }
+  const existingBinaryState = bins?.libs[binaryPath]
+  if (!existingBinaryState) {
+    const item = await window.showInformationMessage(
+      `Your VSCode workspace is defining a custom binary path for the Prisma extension:"${binaryPath}" . Do you want to trust this binary and let the extension execute it?`,
+      {
+        modal: true,
+      },
+      { title: 'Allow', value: BinaryPopupStatus.Allow },
+      { title: 'Deny', value: BinaryPopupStatus.Deny },
+    )
+    if (item === undefined) {
+      // dialog was cancelled
+      return false
+    }
+
+    let result = false
+
+    if (item.value === BinaryPopupStatus.Allow) {
+      result = true
+    }
+
+    if (item.value === BinaryPopupStatus.Deny) {
+      result = false
+    }
+
+    // store the state
+    bins = bins ? bins : { libs: {} }
+    bins.libs[binaryPath] = { allowed: result }
+    await context.globalState.update(PRISMA_ALLOWED_BINS_KEY, bins)
+    return result
+  } else {
+    return existingBinaryState.allowed
+  }
+}
+
+export const printBinaryCheckWarning = async () => {
+  await window.showWarningMessage(
+    "Prisma extension hasn't got the approval for usage for binary defined in settings. Please either change the binary path or reset library execution decisions.",
+  )
+}

--- a/packages/vscode/src/binaryValidator.ts
+++ b/packages/vscode/src/binaryValidator.ts
@@ -59,6 +59,6 @@ export const checkAndAskForBinaryExecution = async (
 
 export const printBinaryCheckWarning = async () => {
   await window.showWarningMessage(
-    "Prisma extension's binary defined in settings was not approved. Please either change the binary path or reset the approval by opening the VS Code command palette and search for 'Reset Binary execution decisions', then press Enter.",
+    "Execution of Prisma extension's binary defined in settings was not allowed. Please either change the binary path or reset the approval by opening the VS Code command palette and search for 'Reset Binary execution decisions', then press Enter.",
   )
 }

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -6,6 +6,7 @@ import {
   CodeActionContext,
   Command,
   commands,
+  ExtensionContext,
   Range,
   TextDocument,
   window,
@@ -21,6 +22,12 @@ import {
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient/node'
+import {
+  BinaryStorage,
+  checkAndAskForBinaryExecution,
+  printBinaryCheckWarning,
+  PRISMA_ALLOWED_BINS_KEY,
+} from '../../binaryValidator'
 import TelemetryReporter from '../../telemetryReporter'
 import {
   applySnippetWorkspaceEdit,
@@ -28,6 +35,7 @@ import {
   checkForOtherPrismaExtension,
   isDebugOrTestSession,
   isSnippetEdit,
+  restartClient,
 } from '../../util'
 import { PrismaVSCodePlugin } from '../types'
 
@@ -53,152 +61,183 @@ function createLanguageServer(
   )
 }
 
+const activateExtension = async (context: ExtensionContext) => {
+  const isDebugOrTest = isDebugOrTestSession()
+  const rootPath = workspace.rootPath
+
+  if (rootPath) {
+    watcher = chokidar.watch(
+      path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
+      {
+        usePolling: false,
+        followSymlinks: false,
+      },
+    )
+  }
+  if (isDebugMode() || isE2ETestOnPullRequest()) {
+    // use LSP from folder for debugging
+    console.log('Using local LSP')
+    serverModule = context.asAbsolutePath(
+      path.join('../../packages/language-server/dist/src/bin'),
+    )
+  } else {
+    console.log('Using published LSP.')
+    // use published npm package for production
+    serverModule = require.resolve('@prisma/language-server/dist/src/bin')
+  }
+
+  // The debug options for the server
+  // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+  const debugOptions = {
+    execArgv: ['--nolazy', '--inspect=6009'],
+    env: { DEBUG: true },
+  }
+
+  // If the extension is launched in debug mode then the debug server options are used
+  // Otherwise the run options are used
+  const serverOptions: ServerOptions = {
+    run: { module: serverModule, transport: TransportKind.ipc },
+    debug: {
+      module: serverModule,
+      transport: TransportKind.ipc,
+      options: debugOptions,
+    },
+  }
+
+  // Options to control the language client
+  const clientOptions: LanguageClientOptions = {
+    // Register the server for prisma documents
+    documentSelector: [{ scheme: 'file', language: 'prisma' }],
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    middleware: {
+      async provideCodeActions(
+        document: TextDocument,
+        range: Range,
+        context: CodeActionContext,
+        token: CancellationToken,
+        _: ProvideCodeActionsSignature,
+      ) {
+        const params: CodeActionParams = {
+          textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
+            document,
+          ),
+          range: client.code2ProtocolConverter.asRange(range),
+          context: client.code2ProtocolConverter.asCodeActionContext(context),
+        }
+        return client.sendRequest(CodeActionRequest.type, params, token).then(
+          (values) => {
+            if (values === null) return undefined
+            const result: (CodeAction | Command)[] = []
+            for (const item of values) {
+              if (lsCodeAction.is(item)) {
+                const action = client.protocol2CodeConverter.asCodeAction(item)
+                if (
+                  isSnippetEdit(
+                    item,
+                    client.code2ProtocolConverter.asTextDocumentIdentifier(
+                      document,
+                    ),
+                  ) &&
+                  item.edit !== undefined
+                ) {
+                  action.command = {
+                    command: 'prisma.applySnippetWorkspaceEdit',
+                    title: '',
+                    arguments: [action.edit],
+                  }
+                  action.edit = undefined
+                }
+                result.push(action)
+              } else {
+                const command = client.protocol2CodeConverter.asCommand(item)
+                result.push(command)
+              }
+            }
+            return result
+          },
+          (_) => undefined,
+        )
+      },
+    } as any,
+  }
+
+  // Create the language client
+  client = createLanguageServer(serverOptions, clientOptions)
+
+  const disposable = client.start()
+
+  // Start the client. This will also launch the server
+  context.subscriptions.push(disposable)
+
+  context.subscriptions.push(
+    commands.registerCommand('prisma.restartLanguageServer', async () => {
+      await client.stop()
+      client = createLanguageServer(serverOptions, clientOptions)
+      context.subscriptions.push(client.start())
+      await client.onReady()
+      window.showInformationMessage('Prisma language server restarted.') // eslint-disable-line @typescript-eslint/no-floating-promises
+    }),
+    commands.registerCommand(
+      'prisma.applySnippetWorkspaceEdit',
+      applySnippetWorkspaceEdit(),
+    ),
+    commands.registerCommand('prisma.resetBinDecisions', async () => {
+      await context.globalState.update(PRISMA_ALLOWED_BINS_KEY, { libs: {} })
+      await restartClient(context, client)
+    }),
+  )
+
+  if (!isDebugOrTest) {
+    // eslint-disable-next-line
+    const extensionId = 'prisma.' + packageJson.name
+    // eslint-disable-next-line
+    const extensionVersion = packageJson.version
+    telemetry = new TelemetryReporter(extensionId, extensionVersion)
+    context.subscriptions.push(telemetry)
+    await telemetry.sendTelemetryEvent()
+    if (extensionId === 'prisma.prisma-insider') {
+      checkForOtherPrismaExtension()
+    }
+  }
+
+  checkForMinimalColorTheme()
+  if (watcher) {
+    watcher.on('change', (path) => {
+      console.log(`File ${path} has been changed. Restarting TS Server.`)
+      commands.executeCommand('typescript.restartTsServer') // eslint-disable-line
+    })
+  }
+}
+
 const plugin: PrismaVSCodePlugin = {
   name: 'prisma-language-server',
   enabled: () => true,
   activate: async (context) => {
-    const isDebugOrTest = isDebugOrTestSession()
-    const rootPath = workspace.rootPath
-
-    if (rootPath) {
-      watcher = chokidar.watch(
-        path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
-        {
-          usePolling: false,
-          followSymlinks: false,
-        },
-      )
-    }
-    if (isDebugMode() || isE2ETestOnPullRequest()) {
-      // use LSP from folder for debugging
-      console.log('Using local LSP')
-      serverModule = context.asAbsolutePath(
-        path.join('../../packages/language-server/dist/src/bin'),
-      )
-    } else {
-      console.log('Using published LSP.')
-      // use published npm package for production
-      serverModule = require.resolve('@prisma/language-server/dist/src/bin')
-    }
-
-    // The debug options for the server
-    // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-    const debugOptions = {
-      execArgv: ['--nolazy', '--inspect=6009'],
-      env: { DEBUG: true },
-    }
-
-    // If the extension is launched in debug mode then the debug server options are used
-    // Otherwise the run options are used
-    const serverOptions: ServerOptions = {
-      run: { module: serverModule, transport: TransportKind.ipc },
-      debug: {
-        module: serverModule,
-        transport: TransportKind.ipc,
-        options: debugOptions,
-      },
-    }
-
-    // Options to control the language client
-    const clientOptions: LanguageClientOptions = {
-      // Register the server for prisma documents
-      documentSelector: [{ scheme: 'file', language: 'prisma' }],
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      middleware: {
-        async provideCodeActions(
-          document: TextDocument,
-          range: Range,
-          context: CodeActionContext,
-          token: CancellationToken,
-          _: ProvideCodeActionsSignature,
-        ) {
-          const params: CodeActionParams = {
-            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
-              document,
-            ),
-            range: client.code2ProtocolConverter.asRange(range),
-            context: client.code2ProtocolConverter.asCodeActionContext(context),
-          }
-          return client.sendRequest(CodeActionRequest.type, params, token).then(
-            (values) => {
-              if (values === null) return undefined
-              const result: (CodeAction | Command)[] = []
-              for (const item of values) {
-                if (lsCodeAction.is(item)) {
-                  const action = client.protocol2CodeConverter.asCodeAction(
-                    item,
-                  )
-                  if (
-                    isSnippetEdit(
-                      item,
-                      client.code2ProtocolConverter.asTextDocumentIdentifier(
-                        document,
-                      ),
-                    ) &&
-                    item.edit !== undefined
-                  ) {
-                    action.command = {
-                      command: 'prisma.applySnippetWorkspaceEdit',
-                      title: '',
-                      arguments: [action.edit],
-                    }
-                    action.edit = undefined
-                  }
-                  result.push(action)
-                } else {
-                  const command = client.protocol2CodeConverter.asCommand(item)
-                  result.push(command)
-                }
-              }
-              return result
-            },
-            (_) => undefined,
-          )
-        },
-      } as any,
-    }
-
-    // Create the language client
-    client = createLanguageServer(serverOptions, clientOptions)
-
-    const disposable = client.start()
-
-    // Start the client. This will also launch the server
-    context.subscriptions.push(disposable)
-
-    context.subscriptions.push(
-      commands.registerCommand('prisma.restartLanguageServer', async () => {
-        await client.stop()
-        client = createLanguageServer(serverOptions, clientOptions)
-        context.subscriptions.push(client.start())
-        await client.onReady()
-        window.showInformationMessage('Prisma language server restarted.') // eslint-disable-line @typescript-eslint/no-floating-promises
-      }),
-      commands.registerCommand(
-        'prisma.applySnippetWorkspaceEdit',
-        applySnippetWorkspaceEdit(),
-      ),
+    const config = workspace.getConfiguration('prisma')
+    const allowedBins = context.globalState.get<BinaryStorage>(
+      PRISMA_ALLOWED_BINS_KEY,
     )
 
-    if (!isDebugOrTest) {
-      // eslint-disable-next-line
-      const extensionId = 'prisma.' + packageJson.name
-      // eslint-disable-next-line
-      const extensionVersion = packageJson.version
-      telemetry = new TelemetryReporter(extensionId, extensionVersion)
-      context.subscriptions.push(telemetry)
-      await telemetry.sendTelemetryEvent()
-      if (extensionId === 'prisma.prisma-insider') {
-        checkForOtherPrismaExtension()
-      }
-    }
+    workspace.onDidChangeConfiguration(
+      async (e) => {
+        const binChanged = e.affectsConfiguration('prisma.prismaFmtBinPath')
+        if (binChanged) {
+          await restartClient(context, client)
+        }
+      },
+      null,
+      context.subscriptions,
+    )
 
-    checkForMinimalColorTheme()
-    if (watcher) {
-      watcher.on('change', (path) => {
-        console.log(`File ${path} has been changed. Restarting TS Server.`)
-        commands.executeCommand('typescript.restartTsServer') // eslint-disable-line
-      })
+    const launchAllowed = await checkAndAskForBinaryExecution(
+      context,
+      config.get('prismaFmtBinPath'),
+      allowedBins,
+    )
+    if (launchAllowed) {
+      await activateExtension(context)
+    } else {
+      await printBinaryCheckWarning()
     }
   },
   deactivate: async () => {

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -36,6 +36,7 @@ import {
   isDebugOrTestSession,
   isSnippetEdit,
   restartClient,
+  createLanguageServer,
 } from '../../util'
 import { PrismaVSCodePlugin } from '../types'
 
@@ -49,118 +50,11 @@ let watcher: chokidar.FSWatcher
 const isDebugMode = () => process.env.VSCODE_DEBUG_MODE === 'true'
 const isE2ETestOnPullRequest = () => process.env.localLSP === 'true'
 
-function createLanguageServer(
+const activateClient = (
+  context: ExtensionContext,
   serverOptions: ServerOptions,
   clientOptions: LanguageClientOptions,
-): LanguageClient {
-  return new LanguageClient(
-    'prisma',
-    'Prisma Language Server',
-    serverOptions,
-    clientOptions,
-  )
-}
-
-const activateExtension = async (context: ExtensionContext) => {
-  const isDebugOrTest = isDebugOrTestSession()
-  const rootPath = workspace.rootPath
-
-  if (rootPath) {
-    watcher = chokidar.watch(
-      path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
-      {
-        usePolling: false,
-        followSymlinks: false,
-      },
-    )
-  }
-  if (isDebugMode() || isE2ETestOnPullRequest()) {
-    // use LSP from folder for debugging
-    console.log('Using local LSP')
-    serverModule = context.asAbsolutePath(
-      path.join('../../packages/language-server/dist/src/bin'),
-    )
-  } else {
-    console.log('Using published LSP.')
-    // use published npm package for production
-    serverModule = require.resolve('@prisma/language-server/dist/src/bin')
-  }
-
-  // The debug options for the server
-  // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-  const debugOptions = {
-    execArgv: ['--nolazy', '--inspect=6009'],
-    env: { DEBUG: true },
-  }
-
-  // If the extension is launched in debug mode then the debug server options are used
-  // Otherwise the run options are used
-  const serverOptions: ServerOptions = {
-    run: { module: serverModule, transport: TransportKind.ipc },
-    debug: {
-      module: serverModule,
-      transport: TransportKind.ipc,
-      options: debugOptions,
-    },
-  }
-
-  // Options to control the language client
-  const clientOptions: LanguageClientOptions = {
-    // Register the server for prisma documents
-    documentSelector: [{ scheme: 'file', language: 'prisma' }],
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    middleware: {
-      async provideCodeActions(
-        document: TextDocument,
-        range: Range,
-        context: CodeActionContext,
-        token: CancellationToken,
-        _: ProvideCodeActionsSignature,
-      ) {
-        const params: CodeActionParams = {
-          textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
-            document,
-          ),
-          range: client.code2ProtocolConverter.asRange(range),
-          context: client.code2ProtocolConverter.asCodeActionContext(context),
-        }
-        return client.sendRequest(CodeActionRequest.type, params, token).then(
-          (values) => {
-            if (values === null) return undefined
-            const result: (CodeAction | Command)[] = []
-            for (const item of values) {
-              if (lsCodeAction.is(item)) {
-                const action = client.protocol2CodeConverter.asCodeAction(item)
-                if (
-                  isSnippetEdit(
-                    item,
-                    client.code2ProtocolConverter.asTextDocumentIdentifier(
-                      document,
-                    ),
-                  ) &&
-                  item.edit !== undefined
-                ) {
-                  action.command = {
-                    command: 'prisma.applySnippetWorkspaceEdit',
-                    title: '',
-                    arguments: [action.edit],
-                  }
-                  action.edit = undefined
-                }
-                result.push(action)
-              } else {
-                const command = client.protocol2CodeConverter.asCommand(item)
-                result.push(command)
-              }
-            }
-            return result
-          },
-          (_) => undefined,
-        )
-      },
-    } as any,
-  }
-
+) => {
   // Create the language client
   client = createLanguageServer(serverOptions, clientOptions)
 
@@ -168,51 +62,112 @@ const activateExtension = async (context: ExtensionContext) => {
 
   // Start the client. This will also launch the server
   context.subscriptions.push(disposable)
-
-  context.subscriptions.push(
-    commands.registerCommand('prisma.restartLanguageServer', async () => {
-      await client.stop()
-      client = createLanguageServer(serverOptions, clientOptions)
-      context.subscriptions.push(client.start())
-      await client.onReady()
-      window.showInformationMessage('Prisma language server restarted.') // eslint-disable-line @typescript-eslint/no-floating-promises
-    }),
-    commands.registerCommand(
-      'prisma.applySnippetWorkspaceEdit',
-      applySnippetWorkspaceEdit(),
-    ),
-    commands.registerCommand('prisma.resetBinDecisions', async () => {
-      await context.globalState.update(PRISMA_ALLOWED_BINS_KEY, { libs: {} })
-      await restartClient(context, client)
-    }),
-  )
-
-  if (!isDebugOrTest) {
-    // eslint-disable-next-line
-    const extensionId = 'prisma.' + packageJson.name
-    // eslint-disable-next-line
-    const extensionVersion = packageJson.version
-    telemetry = new TelemetryReporter(extensionId, extensionVersion)
-    context.subscriptions.push(telemetry)
-    await telemetry.sendTelemetryEvent()
-    if (extensionId === 'prisma.prisma-insider') {
-      checkForOtherPrismaExtension()
-    }
-  }
-
-  checkForMinimalColorTheme()
-  if (watcher) {
-    watcher.on('change', (path) => {
-      console.log(`File ${path} has been changed. Restarting TS Server.`)
-      commands.executeCommand('typescript.restartTsServer') // eslint-disable-line
-    })
-  }
 }
 
 const plugin: PrismaVSCodePlugin = {
   name: 'prisma-language-server',
   enabled: () => true,
   activate: async (context) => {
+    const isDebugOrTest = isDebugOrTestSession()
+    const rootPath = workspace.rootPath
+
+    if (rootPath) {
+      watcher = chokidar.watch(
+        path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
+        {
+          usePolling: false,
+          followSymlinks: false,
+        },
+      )
+    }
+    if (isDebugMode() || isE2ETestOnPullRequest()) {
+      // use LSP from folder for debugging
+      console.log('Using local LSP')
+      serverModule = context.asAbsolutePath(
+        path.join('../../packages/language-server/dist/src/bin'),
+      )
+    } else {
+      console.log('Using published LSP.')
+      // use published npm package for production
+      serverModule = require.resolve('@prisma/language-server/dist/src/bin')
+    }
+
+    // The debug options for the server
+    // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+    const debugOptions = {
+      execArgv: ['--nolazy', '--inspect=6009'],
+      env: { DEBUG: true },
+    }
+
+    // If the extension is launched in debug mode then the debug server options are used
+    // Otherwise the run options are used
+    const serverOptions: ServerOptions = {
+      run: { module: serverModule, transport: TransportKind.ipc },
+      debug: {
+        module: serverModule,
+        transport: TransportKind.ipc,
+        options: debugOptions,
+      },
+    }
+
+    // Options to control the language client
+    const clientOptions: LanguageClientOptions = {
+      // Register the server for prisma documents
+      documentSelector: [{ scheme: 'file', language: 'prisma' }],
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      middleware: {
+        async provideCodeActions(
+          document: TextDocument,
+          range: Range,
+          context: CodeActionContext,
+          token: CancellationToken,
+          _: ProvideCodeActionsSignature,
+        ) {
+          const params: CodeActionParams = {
+            textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(
+              document,
+            ),
+            range: client.code2ProtocolConverter.asRange(range),
+            context: client.code2ProtocolConverter.asCodeActionContext(context),
+          }
+          return client.sendRequest(CodeActionRequest.type, params, token).then(
+            (values) => {
+              if (values === null) return undefined
+              const result: (CodeAction | Command)[] = []
+              for (const item of values) {
+                if (lsCodeAction.is(item)) {
+                  const action = client.protocol2CodeConverter.asCodeAction(
+                    item,
+                  )
+                  if (
+                    isSnippetEdit(
+                      item,
+                      client.code2ProtocolConverter.asTextDocumentIdentifier(
+                        document,
+                      ),
+                    ) &&
+                    item.edit !== undefined
+                  ) {
+                    action.command = {
+                      command: 'prisma.applySnippetWorkspaceEdit',
+                      title: '',
+                      arguments: [action.edit],
+                    }
+                    action.edit = undefined
+                  }
+                  result.push(action)
+                } else {
+                  const command = client.protocol2CodeConverter.asCommand(item)
+                  result.push(command)
+                }
+              }
+              return result
+            },
+            (_) => undefined,
+          )
+        },
+      } as any,
+    }
     const config = workspace.getConfiguration('prisma')
     const allowedBins = context.globalState.get<BinaryStorage>(
       PRISMA_ALLOWED_BINS_KEY,
@@ -222,7 +177,12 @@ const plugin: PrismaVSCodePlugin = {
       async (e) => {
         const binChanged = e.affectsConfiguration('prisma.prismaFmtBinPath')
         if (binChanged) {
-          await restartClient(context, client)
+          client = await restartClient(
+            context,
+            client,
+            serverOptions,
+            clientOptions,
+          )
         }
       },
       null,
@@ -234,10 +194,77 @@ const plugin: PrismaVSCodePlugin = {
       config.get('prismaFmtBinPath'),
       allowedBins,
     )
+    context.subscriptions.push(
+      commands.registerCommand('prisma.resetAllBinDecisions', async () => {
+        await context.globalState.update(PRISMA_ALLOWED_BINS_KEY, { libs: {} })
+        client = await restartClient(
+          context,
+          client,
+          serverOptions,
+          clientOptions,
+        )
+      }),
+      commands.registerCommand(
+        'prisma.resetCurrentFmtBinDecision',
+        async () => {
+          const decisions = context.globalState.get<BinaryStorage>(
+            PRISMA_ALLOWED_BINS_KEY,
+          )
+          const currentBin: string | undefined = workspace
+            .getConfiguration('prisma')
+            .get('prismaFmtBinPath')
+          if (decisions && currentBin && currentBin !== '') {
+            delete decisions.libs[currentBin]
+          }
+          await context.globalState.update(PRISMA_ALLOWED_BINS_KEY, decisions)
+          client = await restartClient(
+            context,
+            client,
+            serverOptions,
+            clientOptions,
+          )
+        },
+      ),
+      commands.registerCommand('prisma.restartLanguageServer', async () => {
+        client = await restartClient(
+          context,
+          client,
+          serverOptions,
+          clientOptions,
+        )
+        window.showInformationMessage('Prisma language server restarted.') // eslint-disable-line @typescript-eslint/no-floating-promises
+      }),
+      commands.registerCommand(
+        'prisma.applySnippetWorkspaceEdit',
+        applySnippetWorkspaceEdit(),
+      ),
+    )
+
     if (launchAllowed) {
-      await activateExtension(context)
+      activateClient(context, serverOptions, clientOptions)
     } else {
       await printBinaryCheckWarning()
+    }
+
+    if (!isDebugOrTest) {
+      // eslint-disable-next-line
+      const extensionId = 'prisma.' + packageJson.name
+      // eslint-disable-next-line
+      const extensionVersion = packageJson.version
+      telemetry = new TelemetryReporter(extensionId, extensionVersion)
+      context.subscriptions.push(telemetry)
+      await telemetry.sendTelemetryEvent()
+      if (extensionId === 'prisma.prisma-insider') {
+        checkForOtherPrismaExtension()
+      }
+    }
+
+    checkForMinimalColorTheme()
+    if (watcher) {
+      watcher.on('change', (path) => {
+        console.log(`File ${path} has been changed. Restarting TS Server.`)
+        commands.executeCommand('typescript.restartTsServer') // eslint-disable-line
+      })
     }
   },
   deactivate: async () => {

--- a/packages/vscode/src/test/binaryValidator.test.ts
+++ b/packages/vscode/src/test/binaryValidator.test.ts
@@ -12,9 +12,8 @@ suite('Binary validation test', () => {
       },
     },
   }
+  const path = '/user/bin/test'
   test('should return false when path is in deny state', async () => {
-    const path = '/user/bin/test'
-
     const bins: BinaryStorage = { libs: { [path]: { allowed: false } } }
 
     const checkResult = await checkAndAskForBinaryExecution(context, path, bins)
@@ -22,8 +21,6 @@ suite('Binary validation test', () => {
   })
 
   test('should return true when path is in allow state', async () => {
-    const path = '/user/bin/test'
-
     const bins: BinaryStorage = { libs: { [path]: { allowed: true } } }
 
     const checkResult = await checkAndAskForBinaryExecution(context, path, bins)

--- a/packages/vscode/src/test/binaryValidator.test.ts
+++ b/packages/vscode/src/test/binaryValidator.test.ts
@@ -1,0 +1,32 @@
+import {
+  checkAndAskForBinaryExecution,
+  BinaryStorage,
+} from '../binaryValidator'
+import * as asset from 'assert'
+
+suite('Binary validation test', () => {
+  const context: any = {
+    globalState: {
+      update: () => {
+        /**/
+      },
+    },
+  }
+  test('should return false when path is in deny state', async () => {
+    const path = '/user/bin/test'
+
+    const bins: BinaryStorage = { libs: { [path]: { allowed: false } } }
+
+    const checkResult = await checkAndAskForBinaryExecution(context, path, bins)
+    asset.strictEqual(checkResult, false)
+  })
+
+  test('should return true when path is in allow state', async () => {
+    const path = '/user/bin/test'
+
+    const bins: BinaryStorage = { libs: { [path]: { allowed: true } } }
+
+    const checkResult = await checkAndAskForBinaryExecution(context, path, bins)
+    asset.strictEqual(checkResult, true)
+  })
+})


### PR DESCRIPTION
TODOS:
- [x] Allowlist for custom bins
- [x] Reask for validation on settings change
- [x] Add option to reset the current binary's status (`prisma.resetCurrentFmtBinDecision` option)
- [x] Add option to reset the whole allowList (`prisma.resetAllBinDecisions` option)
- [x] Basic Tests