### PR TITLE
feat: referential action completions

### DIFF
--- a/packages/language-server/src/MessageHandler.ts
+++ b/packages/language-server/src/MessageHandler.ts
@@ -107,9 +107,8 @@ export async function handleDiagnosticsRequest(
 
   // check for experimentalFeatures inside generator block
   if (document.getText().includes('experimentalFeatures')) {
-    const experimentalFeaturesRange:
-      | Range
-      | undefined = getExperimentalFeaturesRange(document)
+    const experimentalFeaturesRange: Range | undefined =
+      getExperimentalFeaturesRange(document)
     if (experimentalFeaturesRange) {
       diagnostics.push({
         severity: DiagnosticSeverity.Warning,
@@ -200,14 +199,9 @@ export async function handleDocumentFormatting(
 ): Promise<TextEdit[]> {
   const options = params.options
 
-  return format(
-    binPath,
-    options.tabSize,
-    document.getText(),
-    onError,
-  ).then((formatted) => [
-    TextEdit.replace(fullDocumentRange(document), formatted),
-  ])
+  return format(binPath, options.tabSize, document.getText(), onError).then(
+    (formatted) => [TextEdit.replace(fullDocumentRange(document), formatted)],
+  )
 }
 
 export function handleHoverRequest(
@@ -339,8 +333,10 @@ export function handleCompletionRequest(
         return getSuggestionsForInsideAttributes(
           currentLineUntrimmed,
           lines,
+          document,
           position,
           foundBlock,
+          binPath,
         )
       }
 

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -201,6 +201,14 @@
         {
           "label": "references",
           "documentation": "A list of field references of the model on *the other side of the relation*."
+        },
+        {
+          "label": "onDelete",
+          "documentation": "Specifies the action to perform when a referenced row in the referenced table is being deleted."
+        },
+        {
+          "label": "onUpdate",
+          "documentation": "Specifies the action to perform when a referenced column in the referenced table is being updated to a new value."
         }
       ]
     },
@@ -228,6 +236,18 @@
       "label": "fields: []",
       "fullSignature": "fields: []",
       "documentation": "A list of field references of the *current* model.",
+      "params": []
+    },
+    {
+      "label": "onDelete: ",
+      "fullSignature": "onDelete: ",
+      "documentation": "Specifies the action to perform when a referenced row in the referenced table is being deleted.",
+      "params": []
+    },
+    {
+      "label": "onUpdate: ",
+      "fullSignature": "onUpdate: ",
+      "documentation": "Specifies the action to perform when a referenced column in the referenced table is being updated to a new value.",
       "params": []
     },
     {

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -208,7 +208,7 @@
         },
         {
           "label": "onUpdate",
-          "documentation": "Specifies the action to perform when a referenced column in the referenced table is being updated to a new value."
+          "documentation": "Specifies the action to perform when a referenced field in the referenced model is being updated to a new value."
         }
       ]
     },

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -204,7 +204,7 @@
         },
         {
           "label": "onDelete",
-          "documentation": "Specifies the action to perform when a referenced row in the referenced table is being deleted."
+          "documentation": "Specifies the action to perform when a referenced entry in the referenced model is being deleted."
         },
         {
           "label": "onUpdate",

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -247,7 +247,7 @@
     {
       "label": "onUpdate: ",
       "fullSignature": "onUpdate: ",
-      "documentation": "Specifies the action to perform when a referenced column in the referenced table is being updated to a new value.",
+      "documentation": "Specifies the action to perform when a referenced field in the referenced model is being updated to a new value.",
       "params": []
     },
     {

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -241,7 +241,7 @@
     {
       "label": "onDelete: ",
       "fullSignature": "onDelete: ",
-      "documentation": "Specifies the action to perform when a referenced row in the referenced table is being deleted.",
+      "documentation": "Specifies the action to perform when a referenced entry in the referenced model is being deleted.",
       "params": []
     },
     {

--- a/packages/language-server/src/prisma-fmt/referentialActions.ts
+++ b/packages/language-server/src/prisma-fmt/referentialActions.ts
@@ -1,0 +1,23 @@
+import execa from 'execa'
+
+export default function referentialActions(
+  execPath: string,
+  text: string,
+  onError?: (errorMessage: string) => void,
+): string[] {
+  const result = execa.sync(execPath, ['referential-actions'], { input: text })
+
+  if (result.exitCode !== 0) {
+    const errorMessage =
+      "prisma-fmt error'd during getting available referential actions.\n"
+
+    if (onError) {
+      onError(errorMessage + result.stderr)
+    }
+
+    console.error(errorMessage)
+    console.error(result.stderr)
+    return []
+  }
+  return JSON.parse(result.stdout) as string[]
+}

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -454,6 +454,7 @@ suite('Quick Fix', () => {
     label: 'fields: []',
     kind: CompletionItemKind.Property,
   }
+
   const referencesProperty = {
     label: 'references: []',
     kind: CompletionItemKind.Property,

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -458,6 +458,14 @@ suite('Quick Fix', () => {
     label: 'references: []',
     kind: CompletionItemKind.Property,
   }
+  const onDeleteProperty = {
+    label: 'onDelete: ',
+    kind: CompletionItemKind.Property
+  }
+  const onUpdateProperty = {
+    label: 'onUpdate: ',
+    kind: CompletionItemKind.Property
+  }
 
   const nameProperty = {
     label: '""',
@@ -646,7 +654,7 @@ suite('Quick Fix', () => {
       { line: 12, character: 26 },
       {
         isIncomplete: false,
-        items: [referencesProperty, fieldsProperty, nameProperty],
+        items: [referencesProperty, fieldsProperty, onDeleteProperty, onUpdateProperty, nameProperty],
       },
     )
     assertCompletion(
@@ -666,7 +674,7 @@ suite('Quick Fix', () => {
       { line: 30, character: 44 },
       {
         isIncomplete: false,
-        items: [fieldsProperty, nameProperty],
+        items: [fieldsProperty, onDeleteProperty, onUpdateProperty, nameProperty],
       },
     )
     assertCompletion(
@@ -674,7 +682,7 @@ suite('Quick Fix', () => {
       { line: 39, character: 45 },
       {
         isIncomplete: false,
-        items: [referencesProperty, nameProperty],
+        items: [referencesProperty, onDeleteProperty, onUpdateProperty, nameProperty],
       },
     )
     assertCompletion(

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -410,6 +410,14 @@ suite('Should auto-complete', () => {
     label: 'references: []',
     kind: vscode.CompletionItemKind.Property,
   }
+  const onDeleteProperty = {
+    label: "onDelete: ",
+    kind: vscode.CompletionItemKind.Property,
+  }
+  const onUpdateProperty = {
+    label: "onUpdate: ",
+    kind: vscode.CompletionItemKind.Property,
+  }
 
   const nameProperty = {
     label: '""',
@@ -545,6 +553,8 @@ suite('Should auto-complete', () => {
         nameProperty,
         fieldsProperty,
         referencesProperty,
+        onDeleteProperty,
+        onUpdateProperty,
       ]),
       true,
     )
@@ -561,13 +571,13 @@ suite('Should auto-complete', () => {
     await testCompletion(
       relationDirectiveUri,
       new vscode.Position(30, 44),
-      new vscode.CompletionList([nameProperty, fieldsProperty]),
+      new vscode.CompletionList([nameProperty, fieldsProperty, onDeleteProperty, onUpdateProperty]),
       true,
     )
     await testCompletion(
       relationDirectiveUri,
       new vscode.Position(39, 45),
-      new vscode.CompletionList([nameProperty, referencesProperty]),
+      new vscode.CompletionList([nameProperty, referencesProperty, onDeleteProperty, onUpdateProperty]),
       true,
     )
     await testCompletion(


### PR DESCRIPTION
This gives support for autocompletion of referential actions after points of `onDelete:` or `onUpdate:` in relations. Needs this branch to get merged first: https://github.com/prisma/prisma-engines/pull/1947

Closes: https://github.com/prisma/language-tools/issues/799