### PR TITLE
test(referential-actions): Tests for autocompletion of the actual action values

### DIFF
--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -700,5 +700,44 @@ suite('Quick Fix', () => {
         ],
       },
     )
+    assertCompletion(
+      relationDirectiveUri,
+      { line: 66, character: 36 },
+      {
+        isIncomplete: false,
+        items: [
+          { label: 'Cascade', kind: CompletionItemKind.Field },
+          { label: 'NoAction', kind: CompletionItemKind.Field },
+          { label: 'Restrict', kind: CompletionItemKind.Field },
+          { label: 'SetNull', kind: CompletionItemKind.Field },
+        ],
+      },
+    )
+    assertCompletion(
+      relationDirectiveUri,
+      { line: 75, character: 36 },
+      {
+        isIncomplete: false,
+        items: [
+          { label: 'Cascade', kind: CompletionItemKind.Field },
+          { label: 'NoAction', kind: CompletionItemKind.Field },
+          { label: 'Restrict', kind: CompletionItemKind.Field },
+          { label: 'SetNull', kind: CompletionItemKind.Field },
+        ],
+      },
+    )
+    assertCompletion(
+      relationDirectiveUri,
+      { line: 84, character: 84 },
+      {
+        isIncomplete: false,
+        items: [
+          { label: 'Cascade', kind: CompletionItemKind.Field },
+          { label: 'NoAction', kind: CompletionItemKind.Field },
+          { label: 'Restrict', kind: CompletionItemKind.Field },
+          { label: 'SetNull', kind: CompletionItemKind.Field },
+        ],
+      },
+    )
   })
 })

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -592,5 +592,38 @@ suite('Should auto-complete', () => {
       ]),
       true,
     )
+    await testCompletion(
+      relationDirectiveUri,
+      new vscode.Position(66, 36),
+      new vscode.CompletionList([
+        { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
+        { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
+        { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
+        { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+      ]),
+      true,
+    )
+    await testCompletion(
+      relationDirectiveUri,
+      new vscode.Position(75, 36),
+      new vscode.CompletionList([
+        { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
+        { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
+        { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
+        { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+      ]),
+      true,
+    )
+    await testCompletion(
+      relationDirectiveUri,
+      new vscode.Position(84, 84),
+      new vscode.CompletionList([
+        { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
+        { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
+        { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
+        { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+      ]),
+      true,
+    )
   })
 })

--- a/packages/vscode/testFixture/completions/relationDirective.prisma
+++ b/packages/vscode/testFixture/completions/relationDirective.prisma
@@ -48,3 +48,39 @@ model OrderItemFive {
     orderId Int
     order Order @relation(fields: [])
 }
+
+model OrderItemSix {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(fields: [orderId], references: [id], )
+}
+
+model OrderItemSeven {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(onDelete: )
+}
+
+model OrderItemEight {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(onUpdate: )
+}
+
+model OrderItemNine {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(fields: [orderId], references: [id], onDelete: )
+}


### PR DESCRIPTION
Failing tests to show that https://github.com/prisma/language-tools/issues/818 indeed does not work.

Not surprising, as this would currently need the `referentialActions` flag which does not appear in tests at all.