### PR TITLE
feat: Store and output CLI version again

### DIFF
--- a/.github/workflows/4_bump_LSP_in_extension.yml
+++ b/.github/workflows/4_bump_LSP_in_extension.yml
@@ -45,12 +45,12 @@ jobs:
         run: |
           sh scripts/set_git_credentials.sh
 
-      - name: Read package.json versions
+      - name: Read package.json versions (engineVersion)
         id: packagejson
         run: |
           PACKAGE_JSON_PATH="./packages/language-server/package.json"
           echo $PACKAGE_JSON_PATH
-          ENGINES_VERSION=$(jq -r '.prisma.version' ${PACKAGE_JSON_PATH}) 
+          ENGINES_VERSION=$(jq -r '.prisma.enginesVersion' ${PACKAGE_JSON_PATH}) 
           echo "::set-output name=engines::$ENGINES_VERSION"
 
       - name: Commit and push to branch 

--- a/.github/workflows/4_bump_LSP_in_extension.yml
+++ b/.github/workflows/4_bump_LSP_in_extension.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           sh scripts/set_git_credentials.sh
 
-      - name: Read package.json versions (engineVersion)
+      - name: Read package.json versions (enginesVersion)
         id: packagejson
         run: |
           PACKAGE_JSON_PATH="./packages/language-server/package.json"

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -10,7 +10,8 @@
     "node": ">=10"
   },
   "prisma": {
-    "version": "93bc5022cab05b6a70742ec1b74ee9a951f7b568"
+    "enginesVersion": "93bc5022cab05b6a70742ec1b74ee9a951f7b568",
+    "cliVersion": "2.27.0-dev.50"
   },
   "bin": {
     "prisma-language-server": "dist/src/bin.js"

--- a/packages/language-server/src/prisma-fmt/util.ts
+++ b/packages/language-server/src/prisma-fmt/util.ts
@@ -18,11 +18,11 @@ let version: string | undefined
  */
 export function getVersion(): string {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  if (!packageJson || !packageJson.prisma || !packageJson.prisma.version) {
+  if (!packageJson || !packageJson.prisma || !packageJson.prisma.enginesVersion) {
     return 'latest'
   }
   // eslint-disable-next-line
-  return packageJson.prisma.version
+  return packageJson.prisma.enginesVersion
 }
 
 /**
@@ -44,13 +44,22 @@ export async function getDownloadURL(): Promise<string> {
   const extension = platform === 'windows' ? '.exe.gz' : '.gz'
   return `https://binaries.prisma.sh/all_commits/${version}/${platform}/prisma-fmt${extension}`
 }
+
 /**
- * Gets Engines Version from `@prisma/get-platform`
+ * Gets Engines Version from package.json, dependencies, `@prisma/get-platform`
  * @returns Something like `2.26.0-23.9b816b3aa13cc270074f172f30d6eda8a8ce867d`
  */
 export function getEnginesVersion(): string {
   // eslint-disable-next-line
   return packageJson.dependencies['@prisma/get-platform']
+}
+
+/**
+ * Gets CLI Version from package.json, prisma, cliVersion
+ * @returns Something like `2.27.0-dev.50`
+ */
+ export function getCliVersion(): string {
+  return packageJson.prisma.cliVersion
 }
 
 export function binaryIsNeeded(path: string): boolean {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -77,6 +77,8 @@ export function startServer(options?: LSPOptions): void {
     )
     const prismaEnginesVersion = util.getEnginesVersion()
     connection.console.info(`Prisma Engines version: ${prismaEnginesVersion}`)
+    const prismaCliVersion = util.getCliVersion()
+    connection.console.info(`Prisma CLI version: ${prismaCliVersion}`)
 
     const result: InitializeResult = {
       capabilities: {

--- a/packages/vscode/release-workflow.md
+++ b/packages/vscode/release-workflow.md
@@ -24,7 +24,7 @@ Note the both `dev` workflow and `latest` workflow call the same scripts, the ch
 1. `check-update.sh` compares `CURRENT_VERSION` (extension) against `NPM_VERSION` of Prisma CLI.
 1. If they are same, this script exits
 1. If they are different, `bump.sh <channel> <version>` is called with `channel=dev` and `version=NPM_VERSION` (i.e. the new version of extension to publish)
-1. `bump.sh` updates the `package.json` files in root, client, server and sets `name`, `displayName`, `version`, `dependencies.@prisma/*` packages, and `prisma.version` values.
+1. `bump.sh` updates the `package.json` files in root, client, server and sets `name`, `displayName`, `version`, `dependencies.@prisma/*` packages, and `prisma.enginesVersion` values.
 1. `check-update.sh` then commits these changes, this commit is required because `vsce publish` (to be run later requires a clean git state)
 1. `npm run vsce:publish <channel> <version>` i.e. `publish.sh <channel> <version>` is then called with `channel=dev` and `version=NPM_VERSION` (i.e. the new version of extension to publish). This command publishes the "Prisma Dev" extension.
 1. `publish.sh` pushes to vscode master repo. Only changes from the dev channel are pushed.
@@ -36,6 +36,6 @@ Note the both `dev` workflow and `latest` workflow call the same scripts, the ch
 1. `check-update.sh` compares `CURRENT_VERSION` (extension) against `NPM_VERSION` of Prisma CLI.
 1. If they are same, this script exits
 1. If they are different, `bump.sh <channel> <version>` is called with `channel=latest` and `version=NPM_VERSION` (i.e. the new version of extension to publish)
-1. `bump.sh` updates the `package.json` files in root, client, server and sets `name`, `displayName`, `version`, `dependencies.@prisma/*` packages, and `prisma.version` values.
+1. `bump.sh` updates the `package.json` files in root, client, server and sets `name`, `displayName`, `version`, `dependencies.@prisma/*` packages, and `prisma.enginesVersion` values.
 1. `check-update.sh` then commits these changes, this commit is required because `vsce publish` (to be run later requires a clean git state)
 1. `npm run vsce:publish <channel> <version>` i.e. `publish.sh <channel> <version>` is then called with `channel=latest` and `version=NPM_VERSION` (i.e. the new version of extension to publish). This command published the "Prisma" extension.

--- a/scripts/update_package_json_files.js
+++ b/scripts/update_package_json_files.js
@@ -54,7 +54,8 @@ function bumpVersionsInRepo({ channel, newExtensionVersion, newPrismaVersion = '
       const engineVersion = prismaCLIDeps['@prisma/engines'] // 2.26.0-23.9b816b3aa13cc270074f172f30d6eda8a8ce867d
       const sha = engineVersion.split('.')[3]
       let languageServerPackageJson = getPackageJsonContent({path: languageServerPackageJsonPath})
-      languageServerPackageJson['prisma']['version'] = sha
+      languageServerPackageJson['prisma']['enginesVersion'] = sha
+      languageServerPackageJson['prisma']['cliVersion'] = newPrismaVersion
       languageServerPackageJson['dependencies']['@prisma/get-platform'] = engineVersion
       languageServerPackageJson['dependencies']['@prisma/fetch-engine'] = engineVersion
       writeJsonToPackageJson({content: languageServerPackageJson, path: languageServerPackageJsonPath})


### PR DESCRIPTION
This makes it possible to log the CLI version again, by writing it to the package.json file the same as the enginesVersion.

Not sure if I got all usages of the `version` (which is now called `enginesVersion`).