### PR TITLE
fix: completion for referentialActions (Cascade,...)

### DIFF
--- a/packages/language-server/src/completion/completionUtil.ts
+++ b/packages/language-server/src/completion/completionUtil.ts
@@ -123,6 +123,22 @@ export const relationArguments: CompletionItem[] =
     (label: string) => label.replace('[]', '[$0]').replace('""', '"$0"'),
   )
 
+export const relationOnDeleteArguments: CompletionItem[] =
+  convertToCompletionItems(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    completions.relationArguments.find((item) => item.label === 'onDelete: ')!
+      .params,
+    CompletionItemKind.Enum,
+  )
+
+export const relationOnUpdateArguments: CompletionItem[] =
+  convertToCompletionItems(
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    completions.relationArguments.find((item) => item.label === 'onUpdate: ')!
+      .params,
+    CompletionItemKind.Enum,
+  )
+
 export const dataSourceUrlArguments: CompletionItem[] =
   convertAttributesToCompletionItems(
     completions.datasourceUrlArguments,

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -33,12 +33,28 @@ function assertCompletion(
   )
 
   assert.ok(completionResult !== undefined)
-  assert.deepStrictEqual(completionResult.isIncomplete, expected.isIncomplete)
-  assert.deepStrictEqual(completionResult.items.length, expected.items.length)
+
+  assert.deepStrictEqual(
+    completionResult.isIncomplete,
+    expected.isIncomplete,
+    // eslint-disable-next-line  @typescript-eslint/restrict-template-expressions
+    `Expected isIncomplete to be ${expected.isIncomplete} suggestions and got ${completionResult.isIncomplete}`,
+  )
+
+  assert.deepStrictEqual(
+    completionResult.items.length,
+    expected.items.length,
+    // eslint-disable-next-line  @typescript-eslint/restrict-template-expressions
+    `Expected ${expected.items.length} suggestions and got ${
+      completionResult.items.length
+    }: ${JSON.stringify(completionResult.items, undefined, 2)}`,
+  )
+
   assert.deepStrictEqual(
     completionResult.items.map((items) => items.label),
     expected.items.map((items) => items.label),
   )
+
   assert.deepStrictEqual(
     completionResult.items.map((item) => item.kind),
     expected.items.map((item) => item.kind),
@@ -745,6 +761,54 @@ suite('Completions', () => {
               onUpdateProperty,
               nameQuotesProperty,
               nameProperty,
+            ],
+          },
+        )
+      })
+      test('@relation(onDelete: |)', () => {
+        assertCompletion(
+          relationDirectiveUri,
+          { line: 66, character: 36 },
+          {
+            isIncomplete: false,
+            items: [
+              { label: 'Cascade', kind: CompletionItemKind.Enum },
+              { label: 'Restrict', kind: CompletionItemKind.Enum },
+              { label: 'NoAction', kind: CompletionItemKind.Enum },
+              { label: 'SetNull', kind: CompletionItemKind.Enum },
+              { label: 'SetDefault', kind: CompletionItemKind.Enum },
+            ],
+          },
+        )
+      })
+      test('@relation(onUpdate: |)', () => {
+        assertCompletion(
+          relationDirectiveUri,
+          { line: 75, character: 36 },
+          {
+            isIncomplete: false,
+            items: [
+              { label: 'Cascade', kind: CompletionItemKind.Enum },
+              { label: 'Restrict', kind: CompletionItemKind.Enum },
+              { label: 'NoAction', kind: CompletionItemKind.Enum },
+              { label: 'SetNull', kind: CompletionItemKind.Enum },
+              { label: 'SetDefault', kind: CompletionItemKind.Enum },
+            ],
+          },
+        )
+      })
+      test('@relation(fields: [orderId], references: [id], onDelete: |)', () => {
+        assertCompletion(
+          relationDirectiveUri,
+          { line: 84, character: 73 },
+          {
+            isIncomplete: false,
+            items: [
+              { label: 'Cascade', kind: CompletionItemKind.Enum },
+              { label: 'Restrict', kind: CompletionItemKind.Enum },
+              { label: 'NoAction', kind: CompletionItemKind.Enum },
+              { label: 'SetNull', kind: CompletionItemKind.Enum },
+              { label: 'SetDefault', kind: CompletionItemKind.Enum },
             ],
           },
         )

--- a/packages/language-server/src/test/prisma-fmt-referentialActions.test.ts
+++ b/packages/language-server/src/test/prisma-fmt-referentialActions.test.ts
@@ -1,0 +1,192 @@
+import assert from 'assert'
+import referentialActions from '../prisma-fmt/referentialActions'
+import * as util from '../prisma-fmt/util'
+
+suite('prisma-fmt subcommand: referential-actions', () => {
+  test('SQLite', async () => {
+    const binPath = await util.getBinPath()
+
+    const schema = `
+        datasource db {
+            provider = "sqlite"
+            url      = env("DATABASE_URL")
+        }
+        
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }`
+
+    const actions = referentialActions(binPath, schema)
+
+    assert.deepStrictEqual(actions, [
+      'Cascade',
+      'Restrict',
+      'NoAction',
+      'SetNull',
+      'SetDefault',
+    ])
+  })
+
+  test('PostgreSQL - minimal', async () => {
+    const binPath = await util.getBinPath()
+
+    const schema = `
+        datasource db {
+            provider = "postgresql"
+            url      = env("DATABASE_URL")
+        }
+        
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }`
+
+    const actions = referentialActions(binPath, schema)
+
+    assert.deepStrictEqual(actions, [
+      'Cascade',
+      'Restrict',
+      'NoAction',
+      'SetNull',
+      'SetDefault',
+    ])
+  })
+
+  test('PostgreSQL - example', async () => {
+    const binPath = await util.getBinPath()
+
+    const schema = `
+        datasource db {
+            provider = "postgresql"
+            url      = env("DATABASE_URL")
+        }
+        
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }
+        
+        model User {
+            id    Int    @id @default(autoincrement())
+            posts Post[]
+        }
+        
+        model Post {
+            id     Int          @id @default(autoincrement())
+            title  String
+            tags   TagOnPosts[]
+            User   User?        @relation(fields: [userId], references: [id])
+            userId Int?
+        }
+        
+        model TagOnPosts {
+            id     Int   @id @default(autoincrement())
+            post   Post? @relation(fields: [postId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+            tag    Tag?  @relation(fields: [tagId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+            postId Int?
+            tagId  Int?
+        }
+        
+        model Tag {
+            id    Int          @id @default(autoincrement())
+            name  String       @unique
+            posts TagOnPosts[]
+        }`
+
+    const actions = referentialActions(binPath, schema)
+
+    assert.deepStrictEqual(actions, [
+      'Cascade',
+      'Restrict',
+      'NoAction',
+      'SetNull',
+      'SetDefault',
+    ])
+  })
+
+  test('MySQL', async () => {
+    const binPath = await util.getBinPath()
+
+    const schema = `
+        datasource db {
+            provider = "mysql"
+            url      = env("DATABASE_URL")
+        }
+        
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }`
+
+    const actions = referentialActions(binPath, schema)
+
+    assert.deepStrictEqual(actions, [
+      'Cascade',
+      'Restrict',
+      'NoAction',
+      'SetNull',
+      'SetDefault',
+    ])
+  })
+
+  test('SQL Server', async () => {
+    const binPath = await util.getBinPath()
+
+    const schema = `
+        datasource db {
+            provider = "sqlserver"
+            url      = env("DATABASE_URL")
+        }
+        
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["microsoftSqlServer", "referentialActions"]
+        }`
+
+    const actions = referentialActions(binPath, schema)
+
+    assert.deepStrictEqual(actions, [
+      'Cascade',
+      'NoAction',
+      'SetNull',
+      'SetDefault',
+    ])
+  })
+
+  test('no datasource should return empty []', async () => {
+    const binPath = await util.getBinPath()
+
+    const schema = `
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }`
+
+    const actions = referentialActions(binPath, schema)
+
+    assert.deepStrictEqual(actions, [])
+  })
+
+  test('invalid schema should return empty []', async () => {
+    const binPath = await util.getBinPath()
+
+    const schema = `
+        datasource db {
+            provider = "sqlite"
+            url      = env("DATABASE_URL")
+        }
+
+        generator client {
+            provider        = "prisma-client-js"
+            previewFeatures = ["referentialActions"]
+        }
+        
+        model { sss } // invalid model
+        `
+
+    const actions = referentialActions(binPath, schema)
+
+    assert.deepStrictEqual(actions, [])
+  })
+})

--- a/packages/language-server/test/fixtures/completions/relationDirective.prisma
+++ b/packages/language-server/test/fixtures/completions/relationDirective.prisma
@@ -57,3 +57,30 @@ model OrderItemSix {
     orderId      Int
     order Order @relation(fields: [orderId], references: [id], )
 }
+
+model OrderItemSeven {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(onDelete: )
+}
+
+model OrderItemEight {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(onUpdate: )
+}
+
+model OrderItemNine {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(fields: [orderId], references: [id], onDelete: )
+}

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -640,6 +640,45 @@ suite('Completions', () => {
           true,
         )
       })
+      test('@relation(onDelete: |)', async () => {
+        await testCompletion(
+          relationDirectiveUri,
+          new vscode.Position(66, 36),
+          new vscode.CompletionList([
+            { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
+            { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
+            { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+          ]),
+          true,
+        )
+      })
+      test('@relation(onUpdate: |)', async () => {
+        await testCompletion(
+          relationDirectiveUri,
+          new vscode.Position(75, 36),
+          new vscode.CompletionList([
+            { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
+            { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
+            { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+          ]),
+          true,
+        )
+      })
+      test('@relation(fields: [orderId], references: [id], onDelete: |)', async () => {
+        await testCompletion(
+          relationDirectiveUri,
+          new vscode.Position(84, 73),
+          new vscode.CompletionList([
+            { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
+            { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
+            { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+          ]),
+          true,
+        )
+      })
     })
   })
 })

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -25,7 +25,7 @@ async function testCompletion(
     actualCompletions.isIncomplete,
     expectedCompletionList.isIncomplete,
     // eslint-disable-next-line  @typescript-eslint/restrict-template-expressions
-    `Expected isIncomplete to be ${actualCompletions.isIncomplete} suggestions and got ${actualCompletions.isIncomplete}`,
+    `Expected isIncomplete to be ${expectedCompletionList.isIncomplete} suggestions and got ${actualCompletions.isIncomplete}`,
   )
 
   assert.deepStrictEqual(

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -24,15 +24,24 @@ async function testCompletion(
   assert.deepStrictEqual(
     actualCompletions.isIncomplete,
     expectedCompletionList.isIncomplete,
+    // eslint-disable-next-line  @typescript-eslint/restrict-template-expressions
+    `Expected isIncomplete to be ${expectedCompletionList.isIncomplete} suggestions and got ${actualCompletions.isIncomplete}`,
   )
+
   assert.deepStrictEqual(
     actualCompletions.items.length,
     expectedCompletionList.items.length,
+    // eslint-disable-next-line  @typescript-eslint/restrict-template-expressions
+    `Expected ${expectedCompletionList.items.length} suggestions and got ${
+      actualCompletions.items.length
+    }: ${JSON.stringify(expectedCompletionList.items, undefined, 2)}`,
   )
+
   assert.deepStrictEqual(
     actualCompletions.items.map((items) => items.label).sort(),
     expectedCompletionList.items.map((items) => items.label).sort(),
   )
+
   assert.deepStrictEqual(
     actualCompletions.items.map((item) => item.kind).sort(),
     expectedCompletionList.items.map((item) => item.kind).sort(),

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -25,7 +25,7 @@ async function testCompletion(
     actualCompletions.isIncomplete,
     expectedCompletionList.isIncomplete,
     // eslint-disable-next-line  @typescript-eslint/restrict-template-expressions
-    `Expected isIncomplete to be ${expectedCompletionList.isIncomplete} suggestions and got ${actualCompletions.isIncomplete}`,
+    `Expected isIncomplete to be ${actualCompletions.isIncomplete} suggestions and got ${actualCompletions.isIncomplete}`,
   )
 
   assert.deepStrictEqual(
@@ -34,7 +34,7 @@ async function testCompletion(
     // eslint-disable-next-line  @typescript-eslint/restrict-template-expressions
     `Expected ${expectedCompletionList.items.length} suggestions and got ${
       actualCompletions.items.length
-    }: ${JSON.stringify(expectedCompletionList.items, undefined, 2)}`,
+    }: ${JSON.stringify(actualCompletions.items, undefined, 2)}`,
   )
 
   assert.deepStrictEqual(
@@ -655,9 +655,10 @@ suite('Completions', () => {
           new vscode.Position(66, 36),
           new vscode.CompletionList([
             { label: 'Cascade', kind: vscode.CompletionItemKind.Enum },
-            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
             { label: 'Restrict', kind: vscode.CompletionItemKind.Enum },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
             { label: 'SetNull', kind: vscode.CompletionItemKind.Enum },
+            { label: 'SetDefault', kind: vscode.CompletionItemKind.Enum },
           ]),
           true,
         )
@@ -668,9 +669,10 @@ suite('Completions', () => {
           new vscode.Position(75, 36),
           new vscode.CompletionList([
             { label: 'Cascade', kind: vscode.CompletionItemKind.Enum },
-            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
             { label: 'Restrict', kind: vscode.CompletionItemKind.Enum },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
             { label: 'SetNull', kind: vscode.CompletionItemKind.Enum },
+            { label: 'SetDefault', kind: vscode.CompletionItemKind.Enum },
           ]),
           true,
         )
@@ -681,9 +683,10 @@ suite('Completions', () => {
           new vscode.Position(84, 73),
           new vscode.CompletionList([
             { label: 'Cascade', kind: vscode.CompletionItemKind.Enum },
-            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
             { label: 'Restrict', kind: vscode.CompletionItemKind.Enum },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
             { label: 'SetNull', kind: vscode.CompletionItemKind.Enum },
+            { label: 'SetDefault', kind: vscode.CompletionItemKind.Enum },
           ]),
           true,
         )

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -654,10 +654,10 @@ suite('Completions', () => {
           relationDirectiveUri,
           new vscode.Position(66, 36),
           new vscode.CompletionList([
-            { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
-            { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
-            { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
-            { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+            { label: 'Cascade', kind: vscode.CompletionItemKind.Enum },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
+            { label: 'Restrict', kind: vscode.CompletionItemKind.Enum },
+            { label: 'SetNull', kind: vscode.CompletionItemKind.Enum },
           ]),
           true,
         )
@@ -667,10 +667,10 @@ suite('Completions', () => {
           relationDirectiveUri,
           new vscode.Position(75, 36),
           new vscode.CompletionList([
-            { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
-            { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
-            { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
-            { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+            { label: 'Cascade', kind: vscode.CompletionItemKind.Enum },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
+            { label: 'Restrict', kind: vscode.CompletionItemKind.Enum },
+            { label: 'SetNull', kind: vscode.CompletionItemKind.Enum },
           ]),
           true,
         )
@@ -680,10 +680,10 @@ suite('Completions', () => {
           relationDirectiveUri,
           new vscode.Position(84, 73),
           new vscode.CompletionList([
-            { label: 'Cascade', kind: vscode.CompletionItemKind.Field },
-            { label: 'NoAction', kind: vscode.CompletionItemKind.Field },
-            { label: 'Restrict', kind: vscode.CompletionItemKind.Field },
-            { label: 'SetNull', kind: vscode.CompletionItemKind.Field },
+            { label: 'Cascade', kind: vscode.CompletionItemKind.Enum },
+            { label: 'NoAction', kind: vscode.CompletionItemKind.Enum },
+            { label: 'Restrict', kind: vscode.CompletionItemKind.Enum },
+            { label: 'SetNull', kind: vscode.CompletionItemKind.Enum },
           ]),
           true,
         )

--- a/packages/vscode/testFixture/completions/relationDirective.prisma
+++ b/packages/vscode/testFixture/completions/relationDirective.prisma
@@ -57,3 +57,30 @@ model OrderItemSix {
     orderId      Int
     order Order @relation(fields: [orderId], references: [id], )
 }
+
+model OrderItemSeven {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(onDelete: )
+}
+
+model OrderItemEight {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(onUpdate: )
+}
+
+model OrderItemNine {
+    id Int @id @default(autoincrement())
+    productName String
+    productPrice Int
+    quantity Int
+    orderId Int
+    order Order @relation(fields: [orderId], references: [id], onDelete: )
+}


### PR DESCRIPTION
Closes https://github.com/prisma/language-tools/issues/818

Adds reliable hardcoded auto-completion + tests for referential actions Cascade, Restrict, NoAction, SetNull, SetDefault

Issue: Restrict will be suggested for SQL server since it's hardcoded.

Hardcoding was the only option right now because prisma-format referential-actions subcommand returns an empty array [] most of the time (probably because it considers the schema invalid)