### PR TITLE
test: add tests for minor version bump

### DIFF
--- a/scripts/__tests__/extension-version.test.js
+++ b/scripts/__tests__/extension-version.test.js
@@ -1,8 +1,10 @@
 const { nextVersion } = require('./../bump_extension_version')
 
 describe('next extension version', () => {
+  //
   // normal insider release
-  it('it should work with an insider release triggered by Prisma CLI', () => {
+  //
+  it('insider release triggered by Prisma CLI', () => {
     expect(
       nextVersion({
         currentVersion: '5.0.1',
@@ -14,7 +16,7 @@ describe('next extension version', () => {
     ).toEqual('5.0.2')
   })
 
-  it('it should work with an insider release triggered by Prisma CLI after an extension only release', () => {
+  it('insider release triggered by Prisma CLI after an extension only release', () => {
     expect(
       nextVersion({
         currentVersion: '5.0.2',
@@ -27,7 +29,7 @@ describe('next extension version', () => {
   })
 
   // patches
-  it('it should work with a first patch release after Prisma CLI stable on Insider', () => {
+  it('first patch release after Prisma CLI stable on Insider', () => {
     expect(
       nextVersion({
         currentVersion: '2.2.1',
@@ -39,7 +41,7 @@ describe('next extension version', () => {
     ).toEqual('3.1.1')
   })
 
-  it('it should work with a second patch release after Prisma CLI stable on Insider', () => {
+  it('econd patch release after Prisma CLI stable on Insider', () => {
     expect(
       nextVersion({
         currentVersion: '3.1.1',
@@ -51,7 +53,7 @@ describe('next extension version', () => {
     ).toEqual('3.1.2')
   })
 
-  it('it should work with a first Prisma CLI patch on stable', () => {
+  it(' a first Prisma CLI patch on stable', () => {
     expect(
       nextVersion({
         currentVersion: '2.5.0',
@@ -63,7 +65,7 @@ describe('next extension version', () => {
     ).toEqual('2.5.1')
   })
 
-  it('it should work with a Prisma CLI patch on stable', () => {
+  it(' a Prisma CLI patch on stable', () => {
     expect(
       nextVersion({
         currentVersion: '2.5.1',
@@ -75,9 +77,10 @@ describe('next extension version', () => {
     ).toEqual('2.5.2')
   })
 
+  //
   // first extension release after Prisma CLI minor update
-
-  it('it should work with the first extension release after a minor Prisma CLI update', () => {
+  //
+  it('first extension release after a minor Prisma CLI update', () => {
     expect(
       nextVersion({
         currentVersion: '5.1.3',
@@ -89,9 +92,46 @@ describe('next extension version', () => {
     ).toEqual('6.0.1')
   })
 
-  // first extension release after Prisma CLI major update
+  it('second extension release after a minor Prisma CLI update', () => {
+    expect(
+      nextVersion({
+        currentVersion: '3.0.0',
+        branch_channel: 'main',
+        prisma_latest: '3.1.0',
+        prisma_dev: '',
+        prisma_patch: '',
+      }),
+    ).toEqual('3.0.1')
+  })
 
-  it('it should work with the first extension release after special major Prisma CLI update (3.0.1)', () => {
+  it('third extension release after a minor Prisma CLI update if latest = 3.1.0', () => {
+    expect(
+      nextVersion({
+        currentVersion: '3.1.0',
+        branch_channel: 'main',
+        prisma_latest: '3.2.0',
+        prisma_dev: '',
+        prisma_patch: '',
+      }),
+    ).toEqual('3.1.1')
+  })
+
+  it('third extension release after a minor Prisma CLI update if latest = 3.1.1', () => {
+    expect(
+      nextVersion({
+        currentVersion: '3.1.1',
+        branch_channel: 'main',
+        prisma_latest: '3.2.0',
+        prisma_dev: '',
+        prisma_patch: '',
+      }),
+    ).toEqual('3.1.2')
+  })
+
+  //
+  // first extension release after Prisma CLI major update
+  //
+  it('first extension release after special major Prisma CLI update (3.0.1)', () => {
     expect(
       nextVersion({
         currentVersion: '2.30.3',
@@ -103,7 +143,7 @@ describe('next extension version', () => {
     ).toEqual('3.0.1')
   })
 
-  it('it should work with the first extension release after a major Prisma CLI update (4.0.0)', () => {
+  it('first extension release after a major Prisma CLI update (4.0.0)', () => {
     expect(
       nextVersion({
         currentVersion: '3.15.9',


### PR DESCRIPTION
Overlap happened with Prisma latest 3.0.1 & 3.1.1

Because npm version is published for `@prisma/language-server` package see:
https://www.npmjs.com/package/@prisma/language-server?activeTab=versions

Tests here show it will be the last overlap happening for 3.x

This will repeat with 4.0 and 4.1, 5.0 and 5.1 until version 31 if nothing is done about it.
https://github.com/prisma/language-tools/issues/868