### PR TITLE
fix(ls): Remove use of obsolete prisma-fmt flags

### DIFF
--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -596,10 +596,7 @@ export function getSuggestionForSupportedFields(
       }
       // previewFeatures
       if (currentLine.startsWith('previewFeatures')) {
-        const generatorPreviewFeatures: string[] = previewFeatures(
-          binPath,
-          false,
-        )
+        const generatorPreviewFeatures: string[] = previewFeatures(binPath)
         if (generatorPreviewFeatures.length > 0) {
           return handlePreviewFeatures(
             generatorPreviewFeatures,

--- a/packages/language-server/src/prisma-fmt/lint.ts
+++ b/packages/language-server/src/prisma-fmt/lint.ts
@@ -13,7 +13,7 @@ export default async function lint(
   onError?: (errorMessage: string) => void,
 ): Promise<LinterError[]> {
   try {
-    const result = await exec(execPath, ['lint', '--no-env-errors'], text)
+    const result = await exec(execPath, ['lint'], text)
     return JSON.parse(result) // eslint-disable-line @typescript-eslint/no-unsafe-return
   } catch (errors) {
     const errorMessage = "prisma-fmt error'd during linting.\n"

--- a/packages/language-server/src/prisma-fmt/previewFeatures.ts
+++ b/packages/language-server/src/prisma-fmt/previewFeatures.ts
@@ -2,15 +2,9 @@ import execa from 'execa'
 
 export default function previewFeatures(
   execPath: string,
-  dataSourceOnly: boolean,
   onError?: (errorMessage: string) => void,
 ): string[] {
-  let result
-  if (dataSourceOnly) {
-    result = execa.sync(execPath, ['preview-features', '--datasource-only'])
-  } else {
-    result = execa.sync(execPath, ['preview-features'])
-  }
+  const result = execa.sync(execPath, ['preview-features'])
 
   if (result.exitCode !== 0) {
     const errorMessage =


### PR DESCRIPTION
- The `--no-env-error` flag on `lint` hasn't had effects in a long time.
- The `--datasource-only` flag is never used. There haven't been
  datasource preview features in a very long time.

Both these flags are removed from prisma-fmt by https://github.com/prisma/prisma-engines/pull/2222/files