### PR TITLE
fix(vscode): watcher ignore dotfiles except .prisma

### DIFF
--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -77,11 +77,13 @@ const plugin: PrismaVSCodePlugin = {
       watcher = chokidar.watch(
         path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
         {
-          usePolling: false,
+          // ignore dotfiles (except .prisma)
+          ignored: /(^|[\/\\])\.(?!prisma)./,
           followSymlinks: false,
         },
       )
     }
+
     if (isDebugMode() || isE2ETestOnPullRequest()) {
       // use LSP from folder for debugging
       console.log('Using local LSP')
@@ -89,7 +91,7 @@ const plugin: PrismaVSCodePlugin = {
         path.join('../../packages/language-server/dist/src/bin'),
       )
     } else {
-      console.log('Using published LSP.')
+      console.log('Using published LSP')
       // use published npm package for production
       serverModule = require.resolve('@prisma/language-server/dist/src/bin')
     }
@@ -131,6 +133,7 @@ const plugin: PrismaVSCodePlugin = {
             range: client.code2ProtocolConverter.asRange(range),
             context: client.code2ProtocolConverter.asCodeActionContext(context),
           }
+
           return client.sendRequest(CodeActionRequest.type, params, token).then(
             (values) => {
               if (values === null) return undefined
@@ -251,15 +254,20 @@ const plugin: PrismaVSCodePlugin = {
       const extensionId = 'prisma.' + packageJson.name
       // eslint-disable-next-line
       const extensionVersion = packageJson.version
+
       telemetry = new TelemetryReporter(extensionId, extensionVersion)
+
       context.subscriptions.push(telemetry)
+
       await telemetry.sendTelemetryEvent()
+
       if (extensionId === 'prisma.prisma-insider') {
         checkForOtherPrismaExtension()
       }
     }
 
     checkForMinimalColorTheme()
+
     if (watcher) {
       watcher.on('change', (path) => {
         console.log(`File ${path} has been changed. Restarting TS Server.`)
@@ -271,9 +279,11 @@ const plugin: PrismaVSCodePlugin = {
     if (!client) {
       return undefined
     }
+
     if (!isDebugOrTestSession()) {
       telemetry.dispose() // eslint-disable-line @typescript-eslint/no-floating-promises
     }
+
     return client.stop()
   },
 }

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -77,7 +77,7 @@ const plugin: PrismaVSCodePlugin = {
       watcher = chokidar.watch(
         path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
         {
-          // ignore dotfiles (except .prisma)
+          // ignore dotfiles (except .prisma) adjusted from chokidar README example
           ignored: /(^|[\/\\])\.(?!prisma)./,
           // When false, only the symlinks themselves will be watched for changes
           // instead of following the link references and bubbling events through the link's path.

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -79,6 +79,8 @@ const plugin: PrismaVSCodePlugin = {
         {
           // ignore dotfiles (except .prisma)
           ignored: /(^|[\/\\])\.(?!prisma)./,
+          // When false, only the symlinks themselves will be watched for changes
+          // instead of following the link references and bubbling events through the link's path.
           followSymlinks: false,
         },
       )


### PR DESCRIPTION
When using 
```
        const watchedPaths = watcher.getWatched();
        console.log(watchedPaths)
```

I could see that the `.bin` folder inside node_modules was being watched unnecessarily.
<img width="929" alt="Screen Shot 2021-09-30 at 14 42 29" src="https://user-images.githubusercontent.com/1328733/135457424-8939bb0a-5815-498d-9831-687e0a964ed0.png">


ignore parameter filters dot folders except `.prisma` meaning the watcher should now watch less folders/files

Related https://github.com/prisma/language-tools/issues/786