### PR TITLE
fix(vscode): limit watcher depth

### DIFF
--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -77,7 +77,13 @@ const plugin: PrismaVSCodePlugin = {
       watcher = chokidar.watch(
         path.join(rootPath, '**/node_modules/.prisma/client/index.d.ts'),
         {
-          usePolling: false,
+          // limits how many levels of subdirectories will be traversed.
+          // Note that `node_modules/.prisma/client/` counts for 3 already
+          // Example
+          // If vs code extension is open in root folder of a project and the path to index.d.ts is
+          // ./server/database/node_modules/.prisma/client/index.d.ts
+          // then the depth is equal to 2 + 3 = 5
+          depth: 7,
           followSymlinks: false,
         },
       )


### PR DESCRIPTION
This PR limits how many levels of subdirectories will be traversed.
Note that `node_modules/.prisma/client/` counts for 3 already

Example
If vs code extension is open in root folder of a project and the path to index.d.ts is
./server/database/node_modules/.prisma/client/index.d.ts
then the depth is equal to 2 + 3 = 5

This PR starts with a depth of 7 so (4 + 3).

Does this depth sounds good to you? What do you think?

Related #786