### PR TITLE
chore: replace deprecated rootPath

### DIFF
--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -71,7 +71,7 @@ const plugin: PrismaVSCodePlugin = {
   enabled: () => true,
   activate: async (context) => {
     const isDebugOrTest = isDebugOrTestSession()
-    const rootPath = workspace.rootPath
+    const rootPath = workspace.workspaceFolders?.[0].uri.path
 
     if (rootPath) {
       watcher = chokidar.watch(


### PR DESCRIPTION
Because:

<img width="696" alt="Screen Shot 2021-09-30 at 16 00 19" src="https://user-images.githubusercontent.com/1328733/135470142-88bb05a6-8543-4cc0-be19-59c91cc8b695.png">

and
```
		/**
         * List of workspace folders or `undefined` when no folder is open.
         * *Note* that the first entry corresponds to the value of `rootPath`.
         */
        export const workspaceFolders: ReadonlyArray<WorkspaceFolder> | undefined;
```