### PR TITLE
feat: add dataproxy completion

### DIFF
--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -417,6 +417,10 @@
     {
       "label": "binary",
       "documentation": "Executable binary."
+    },
+    {
+      "label": "dataproxy",
+      "documentation": "Prisma Data Proxy."
     }
   ],
   "engineTypeArguments": [

--- a/packages/language-server/src/test/completion.test.ts
+++ b/packages/language-server/src/test/completion.test.ts
@@ -354,6 +354,10 @@ suite('Completions', function () {
               label: 'binary',
               kind: CompletionItemKind.Constant,
             },
+            {
+              label: 'dataproxy',
+              kind: CompletionItemKind.Constant,
+            },
           ],
         },
       )

--- a/packages/vscode/src/test/completion.test.ts
+++ b/packages/vscode/src/test/completion.test.ts
@@ -308,6 +308,10 @@ suite('Completions', () => {
               label: 'binary',
               kind: vscode.CompletionItemKind.Constant,
             },
+            {
+              label: 'dataproxy',
+              kind: vscode.CompletionItemKind.Constant,
+            },
           ],
           true,
         ),


### PR DESCRIPTION
adds auto completion for `dataproxy`
```
generator myGenerator {
    engineType = // "library" or "binary" or "dataproxy"
}
```

closes https://github.com/prisma/language-tools/issues/886