### PR TITLE
feat: Minimal flake setup for VSCode extension development

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1637151026,
+        "narHash": "sha256-e2tIMuBKa682J7CkVuMr72K7eCsMDpHpjfhxgxEEggA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9bb171cfc786c072cea848c70b31aca0a2dea48b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,68 @@
+{
+  description = "An optional nix-based development setup";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        apps = {
+          # Build the vscode extension with pinned dependencies.
+          buildVscodeExtension = pkgs.writeShellScriptBin "buildVscodeExtension" ''
+            PATH=${pkgs.nodejs}/bin:${pkgs.jq}/bin:$PATH
+
+            echo -n 'npm --version: '
+            npm --version
+            echo -n 'node --version: '
+            node --version
+
+            echo 'Building language-server...'
+            pushd ./packages/language-server
+            npm clean-install --no-save
+            npm run build
+            popd
+
+            echo 'Building VSCode extension...'
+            pushd ./packages/vscode
+
+            TMP_PACKAGE_JSON=`jq '.dependencies."@prisma/language-server" = "../language-server"' package.json`
+            echo $TMP_PACKAGE_JSON > package.json
+
+            npm install
+            npm run build
+            npm run package -- --no-dependencies
+            popd
+
+            echo 'ok'
+          '';
+          # Start a VSCode instance with completely default configuration in a
+          # temporary directory, but it has the local build of the extension
+          # installed (see buildVscodeExtension above) and an example Prisma
+          # schema.
+          code = pkgs.writeShellScriptBin "code" ''
+            USER_DIR=`mktemp -d`
+            DATA_DIR=`mktemp -d`
+            CODE="${pkgs.vscodium}/bin/codium --user-data-dir $USER_DIR"
+            EXTENSION_FILE=`find ./packages/vscode -name 'prisma-insider*.vsix' -print0`
+
+            if [[ $EXTENSION_FILE == "" ]]; then
+              echo "Could not find extension file in packages/vscode"
+              exit 1
+            fi
+
+            cp ${./packages/vscode/src/test/testDb.prisma} $DATA_DIR/schema.prisma
+            chmod -R 777 $DATA_DIR
+
+            mkdir $USER_DIR $DATA_DIR
+            $CODE --install-extension $EXTENSION_FILE
+            $CODE $DATA_DIR --goto $DATA_DIR/schema.prisma:10
+          '';
+          deleteNodeModules = pkgs.writeShellScriptBin "deleteNodeModules" ''
+            find . -name 'node_modules' -prune
+            find . -name 'node_modules' -prune | xargs rm -rf
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
This first version gives you two commands that are just useful scripts
in development.

- `nix run .#buildVscodeExtension` will run `npm install`, `npm build`
  and `npm package` in packages/vscode, with pinned, reproducible
  dependencies. Nothing more.
- `nix run .#code` starts a VSCode instance with completely default
  configuration in a temporary directory, but it has the local build of
  the extension installed.