### PR TITLE
feat: Log when one of the functions exported from prisma-fmt-wasm is called

### DIFF
--- a/packages/language-server/src/prisma-fmt/format.ts
+++ b/packages/language-server/src/prisma-fmt/format.ts
@@ -5,6 +5,7 @@ export default function format(
   text: string,
   onError?: (errorMessage: string) => void,
 ): string {
+  console.log("running format() from prisma-fmt");
   try {
     return prismaFmt.format(text)
   } catch (errors) {

--- a/packages/language-server/src/prisma-fmt/lint.ts
+++ b/packages/language-server/src/prisma-fmt/lint.ts
@@ -11,6 +11,7 @@ export default function lint(
   text: string,
   onError?: (errorMessage: string) => void,
 ): LinterError[] {
+  console.log("running lint() from prisma-fmt");
   try {
     const result = prismaFmt.lint(text)
     return JSON.parse(result) // eslint-disable-line @typescript-eslint/no-unsafe-return

--- a/packages/language-server/src/prisma-fmt/nativeTypes.ts
+++ b/packages/language-server/src/prisma-fmt/nativeTypes.ts
@@ -11,6 +11,7 @@ export default function nativeTypeConstructors(
   text: string,
   onError?: (errorMessage: string) => void,
 ): NativeTypeConstructors[] {
+  console.log("running native_types() from prisma-fmt");
   try {
     const result = prismaFmt.native_types(text)
     return JSON.parse(result) as NativeTypeConstructors[]

--- a/packages/language-server/src/prisma-fmt/previewFeatures.ts
+++ b/packages/language-server/src/prisma-fmt/previewFeatures.ts
@@ -3,6 +3,7 @@ import prismaFmt from '@prisma/prisma-fmt-wasm'
 export default function previewFeatures(
   onError?: (errorMessage: string) => void,
 ): string[] {
+  console.log("running preview_features() from prisma-fmt");
   try {
     const result = prismaFmt.preview_features()
     return JSON.parse(result) as string[]

--- a/packages/language-server/src/prisma-fmt/referentialActions.ts
+++ b/packages/language-server/src/prisma-fmt/referentialActions.ts
@@ -4,6 +4,7 @@ export default function referentialActions(
   text: string,
   onError?: (errorMessage: string) => void,
 ): string[] {
+  console.log("running referential_actions() from prisma-fmt");
   const result = prismaFmt.referential_actions(text)
   return JSON.parse(result) as string[]
 }


### PR DESCRIPTION
The logs will appear in the `Output` tab at the bottom of the UI. On the
dropdown on the right, select `Prisma Language Server`.