### PR TITLE
fix: Re-calibrate error handling to referentialActions() and nativeTypes()…

### DIFF
--- a/packages/language-server/src/prisma-fmt/format.ts
+++ b/packages/language-server/src/prisma-fmt/format.ts
@@ -5,7 +5,7 @@ export default function format(
   text: string,
   onError?: (errorMessage: string) => void,
 ): string {
-  console.log("running format() from prisma-fmt");
+  console.log('running format() from prisma-fmt')
   try {
     return prismaFmt.format(text)
   } catch (errors) {

--- a/packages/language-server/src/prisma-fmt/lint.ts
+++ b/packages/language-server/src/prisma-fmt/lint.ts
@@ -11,7 +11,7 @@ export default function lint(
   text: string,
   onError?: (errorMessage: string) => void,
 ): LinterError[] {
-  console.log("running lint() from prisma-fmt");
+  console.log('running lint() from prisma-fmt')
   try {
     const result = prismaFmt.lint(text)
     return JSON.parse(result) // eslint-disable-line @typescript-eslint/no-unsafe-return

--- a/packages/language-server/src/prisma-fmt/nativeTypes.ts
+++ b/packages/language-server/src/prisma-fmt/nativeTypes.ts
@@ -11,13 +11,13 @@ export default function nativeTypeConstructors(
   text: string,
   onError?: (errorMessage: string) => void,
 ): NativeTypeConstructors[] {
-  console.log("running native_types() from prisma-fmt");
+  console.log('running native_types() from prisma-fmt')
   try {
     const result = prismaFmt.native_types(text)
     return JSON.parse(result) as NativeTypeConstructors[]
   } catch (err) {
     if (onError) {
-      onError(`${err}`)
+      onError(`prisma-fmt error'd during getting available native types. ${err}`)
     }
 
     return []

--- a/packages/language-server/src/prisma-fmt/previewFeatures.ts
+++ b/packages/language-server/src/prisma-fmt/previewFeatures.ts
@@ -3,7 +3,7 @@ import prismaFmt from '@prisma/prisma-fmt-wasm'
 export default function previewFeatures(
   onError?: (errorMessage: string) => void,
 ): string[] {
-  console.log("running preview_features() from prisma-fmt");
+  console.log('running preview_features() from prisma-fmt')
   try {
     const result = prismaFmt.preview_features()
     return JSON.parse(result) as string[]

--- a/packages/language-server/src/prisma-fmt/referentialActions.ts
+++ b/packages/language-server/src/prisma-fmt/referentialActions.ts
@@ -4,7 +4,15 @@ export default function referentialActions(
   text: string,
   onError?: (errorMessage: string) => void,
 ): string[] {
-  console.log("running referential_actions() from prisma-fmt");
-  const result = prismaFmt.referential_actions(text)
-  return JSON.parse(result) as string[]
+  try {
+    console.log('running referential_actions() from prisma-fmt')
+    const result = prismaFmt.referential_actions(text)
+    return JSON.parse(result) as string[]
+  } catch (err) {
+    if (onError) {
+      onError(`${err}`)
+    }
+
+    return []
+  }
 }

--- a/packages/language-server/src/prisma-fmt/referentialActions.ts
+++ b/packages/language-server/src/prisma-fmt/referentialActions.ts
@@ -10,7 +10,7 @@ export default function referentialActions(
     return JSON.parse(result) as string[]
   } catch (err) {
     if (onError) {
-      onError(`${err}`)
+      onError(`prisma-fmt error'd during getting available referential actions. ${err}`)
     }
 
     return []

--- a/packages/language-server/src/prisma-fmt/util.ts
+++ b/packages/language-server/src/prisma-fmt/util.ts
@@ -2,7 +2,6 @@
  * Imports
  */
 import { getPlatform, Platform } from '@prisma/get-platform'
-import prismaFmt from '@prisma/prisma-fmt-wasm'
 const packageJson = require('../../../package.json') // eslint-disable-line
 
 /**
@@ -52,14 +51,4 @@ export function getEnginesVersion(): string {
  */
 export function getCliVersion(): string {
   return packageJson.prisma.cliVersion
-}
-
-export function getBinaryVersion(): string {
-  try {
-    const output = prismaFmt.version()
-    return output
-  } catch (errors) {
-    console.log(errors)
-    return ''
-  }
 }


### PR DESCRIPTION
… methods in prisma-fmt

closes https://github.com/prisma/language-tools/issues/965