### PR TITLE
feat: Prisma Client raw sql syntax highlighting

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -61,13 +61,29 @@
           "source.js",
           "source.ts",
           "source.js.jsx",
+          "source.jsx",
           "source.tsx",
           "source.vue"
         ],
         "scopeName": "inline.prisma",
-        "path": "./syntaxes/prisma.js.json",
+        "path": "./syntaxes/prisma-inlined.json",
         "embeddedLanguages": {
           "meta.embedded.block.prisma": "prisma"
+        }
+      },
+      {
+        "injectTo": [
+          "source.js",
+          "source.ts",
+          "source.js.jsx",
+          "source.jsx",
+          "source.tsx",
+          "source.vue"
+        ],
+        "scopeName": "client.rawsql.prisma",
+        "path": "./syntaxes/prisma-client-rawsql.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.sql": "sql"
         }
       }
     ],

--- a/packages/vscode/src/manual-test-client-raw-sql-highlight.ts
+++ b/packages/vscode/src/manual-test-client-raw-sql-highlight.ts
@@ -1,0 +1,70 @@
+/* eslint-disable */
+// @ts-nocheck
+async function main() {
+  // How to use?
+  // Build and start VS Code extension
+  // Open this file
+  // Check that highligting works
+  const db: any
+  const raw: any
+  const sql: any
+  const join: any
+  const empty: any
+
+  /**
+   * queryRaw
+   */
+
+  // Test queryRaw(string)
+  const rawQuery = await db.$queryRawUnsafe('SELECT 1') // TODO support ('', ...?)
+
+  // Test queryRaw(string, values)
+  const rawQueryWithValues = await db.$queryRawUnsafe(
+    // TODO
+    'SELECT $1 AS name, $2 AS id',
+    'Alice',
+    42,
+  )
+
+  // Test queryRaw``
+  const rawQueryTemplate = await db.$queryRaw`SELECT 1` // works!
+
+  // Test queryRaw`` with ${param}
+  const rawQueryTemplateWithParams =
+    await db.$queryRaw`SELECT * FROM User WHERE name = ${'Alice'}` // works!
+
+  // Test queryRaw`` with prisma.sql``
+  const rawQueryTemplateFromSqlTemplate = await db.$queryRaw(
+    // TODO support sql``
+    sql`
+      SELECT ${join([raw('email'), raw('id'), raw('name')])}
+      FROM ${raw('User')}
+      ${sql`WHERE name = ${'Alice'}`}
+      ${empty}
+    `,
+  )
+
+  /**
+   * .$executeRaw(
+   */
+
+  // Test .$executeRaw((string)
+  const executeRaw = await db.$executeRawUnsafe(
+    // TODO support ('', ...?)
+    'UPDATE User SET name = $1 WHERE id = $2',
+    'name',
+    'id',
+  )
+
+  // Test .$executeRaw((string, values)
+  const executeRawWithValues = await db.$executeRawUnsafe(
+    // TODO support ('', ...?)
+    'UPDATE User SET name = $1 WHERE id = $2',
+    'Alice',
+    'id',
+  )
+
+  // Test $executeRaw
+  const $executeRawTemplate =
+    await db.$executeRaw`UPDATE User SET name = ${'name'} WHERE id = ${'id'}` // works!
+}

--- a/packages/vscode/syntaxes/prisma-client-rawsql.json
+++ b/packages/vscode/syntaxes/prisma-client-rawsql.json
@@ -1,0 +1,42 @@
+{
+  "name": "Prisma Client: raw SQL highlighting",
+  "scopeName": "client.rawsql.prisma",
+  "fileTypes": ["js", "jsx", "ts", "tsx", "vue"],
+  "injectionSelector": "L:source  -string -comment",
+  "patterns": [
+    {
+      "name": "rawSQLInTaggedTemplates",
+      "contentName": "meta.embedded.block.prisma-client-rawsql",
+      "begin": ".*(\\$queryRaw|\\$executeRaw|\\$queryRawUnsafe|\\$executeRawUnsafe)((`))",
+      "beginbegin": ".*\\$queryRaw((`))",
+      "beginCaptures": {
+        "1": {
+          "name": "entity.name.function.tagged-template.js"
+        },
+        "2": {
+          "name": "string"
+        },
+        "3": {
+          "name": "punctuation.definition.string.template.begin.js"
+        }
+      },
+      "end": "(`)",
+      "endCaptures": {
+        "0": {
+          "name": "string"
+        },
+        "1": {
+          "name": "punctuation.definition.string.template.end.js"
+        }
+      },
+      "patterns": [
+        {
+          "include": "source.ts#template-substitution-element"
+        },
+        {
+          "include": "source.sql"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/vscode/syntaxes/prisma-inlined.json
+++ b/packages/vscode/syntaxes/prisma-inlined.json
@@ -1,4 +1,6 @@
 {
+  "name": "Prisma schema language: inline highlighting",
+  "scopeName": "inline.prisma",
   "fileTypes": ["js", "jsx", "ts", "tsx", "vue"],
   "injectionSelector": "L:source -string -comment",
   "patterns": [
@@ -44,6 +46,5 @@
       },
       "patterns": [{ "include": "source.prisma" }]
     }
-  ],
-  "scopeName": "inline.prisma"
+  ]
 }


### PR DESCRIPTION
https://github.com/prisma/language-tools/issues/74

Looks like this at the moment in my locally built extension
<img width="567" alt="Screen Shot 2021-12-03 at 12 51 06" src="https://user-images.githubusercontent.com/1328733/144599329-f307e3db-0f84-45be-a8db-84f64785a74d.png">

I think there is not much more work to do to finish all the highlighting support we need here

Note: if someone wants to help feel free to contribute!