### PR TITLE
feat: enable/disable File Watcher setting + commands

### DIFF
--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -113,7 +113,7 @@ export function startServer(options?: LSPOptions): void {
 
   // The global settings, used when the `workspace/configuration` request is not supported by the client or is not set by the user.
   // This does not apply to VSCode, as this client supports this setting.
-  // const defaultSettings: LSPSettings = { }
+  // const defaultSettings: LSPSettings = {}
   // let globalSettings: LSPSettings = defaultSettings // eslint-disable-line
 
   // Cache the settings of all open documents
@@ -122,6 +122,7 @@ export function startServer(options?: LSPOptions): void {
     Thenable<LSPSettings>
   >()
 
+  // eslint-disable-line @typescript-eslint/no-unused-vars
   connection.onDidChangeConfiguration((change) => {
     connection.console.info('Configuration changed.')
     if (hasConfigurationCapability) {
@@ -142,9 +143,12 @@ export function startServer(options?: LSPOptions): void {
 
   // function getDocumentSettings(resource: string): Thenable<LSPSettings> {
   //   if (!hasConfigurationCapability) {
-  //     connection.console.info(`Using default prisma-fmt binary path.`)
+  //     connection.console.info(
+  //       `hasConfigurationCapability === false. Defaults will be used.`,
+  //     )
   //     return Promise.resolve(globalSettings)
   //   }
+
   //   let result = documentSettings.get(resource)
   //   if (!result) {
   //     result = connection.workspace.getConfiguration({

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -79,7 +79,7 @@
           "scope": "window",
           "type": "boolean",
           "default": true,
-          "description": "Enable/disable the File Watcher functionnality for Prisma Client."
+          "description": "Enable/disable the File Watcher functionality for Prisma Client."
         },
         "prisma.trace.server": {
           "scope": "window",
@@ -102,12 +102,12 @@
       },
       {
         "command": "prisma.filewatcherEnable",
-        "title": "Enable the File Watcher functionnality for Prisma Client.",
+        "title": "Enable the File Watcher functionality for Prisma Client.",
         "category": "Prisma"
       },
       {
         "command": "prisma.filewatcherDisable",
-        "title": "Disable the File Watcher functionnality for Prisma Client.",
+        "title": "Disable the File Watcher functionality for Prisma Client.",
         "category": "Prisma"
       }
     ]

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -73,8 +73,14 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Language server configuration",
+      "title": "Prisma",
       "properties": {
+        "prisma.fileWatcher": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the File Watcher functionnality for Prisma Client."
+        },
         "prisma.trace.server": {
           "scope": "window",
           "type": "string",
@@ -84,7 +90,7 @@
             "verbose"
           ],
           "default": "off",
-          "description": "Traces the communication between VS Code and the language server."
+          "description": "Setting for logging between the VS Code extension and the language server."
         }
       }
     },
@@ -92,6 +98,16 @@
       {
         "command": "prisma.restartLanguageServer",
         "title": "Restart Language Server",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.filewatcherEnable",
+        "title": "Enable the File Watcher functionnality for Prisma Client.",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.filewatcherDisable",
+        "title": "Disable the File Watcher functionnality for Prisma Client.",
         "category": "Prisma"
       }
     ]


### PR DESCRIPTION
Closes https://github.com/prisma/language-tools/issues/944

Implemented as a boolean
<img width="425" alt="Screen Shot 2021-12-21 at 13 04 46" src="https://user-images.githubusercontent.com/1328733/146927148-af382309-7831-438b-95b9-c0a0d502b8f9.png">
Shows in the UI like
<img width="878" alt="Screen Shot 2021-12-21 at 13 04 14" src="https://user-images.githubusercontent.com/1328733/146927152-c26c1208-38cf-4880-9a1b-4b6335b73328.png">
With commands to set it on/off easily
<img width="591" alt="Screen Shot 2021-12-21 at 13 03 51" src="https://user-images.githubusercontent.com/1328733/146927154-47601ce9-f8dc-4d62-9691-936b7243221a.png">
