### PR TITLE
fix: Use the new prisma-fmt format param

### DIFF
--- a/packages/language-server/src/MessageHandler.ts
+++ b/packages/language-server/src/MessageHandler.ts
@@ -198,9 +198,7 @@ export function handleDocumentFormatting(
   document: TextDocument,
   onError?: (errorMessage: string) => void,
 ): TextEdit[] {
-  const options = params.options
-
-  const formatted = format(options.tabSize, document.getText(), onError)
+  const formatted = format(document.getText(), params, onError)
   return [TextEdit.replace(fullDocumentRange(document), formatted)]
 }
 

--- a/packages/language-server/src/prisma-fmt/format.ts
+++ b/packages/language-server/src/prisma-fmt/format.ts
@@ -1,13 +1,14 @@
 import prismaFmt from '@prisma/prisma-fmt-wasm'
+import { DocumentFormattingParams } from 'vscode-languageserver'
 
 export default function format(
-  identWidth: number,
-  text: string,
+  schema: string,
+  options: DocumentFormattingParams,
   onError?: (errorMessage: string) => void,
 ): string {
   console.log('running format() from prisma-fmt')
   try {
-    return prismaFmt.format(text)
+    return prismaFmt.format(schema, JSON.stringify(options))
   } catch (errors) {
     if (onError) {
       onError(
@@ -19,6 +20,6 @@ export default function format(
     )
     console.warn(errors)
 
-    return text
+    return schema
   }
 }


### PR DESCRIPTION
tabSize is now taken into account again. I confirmed this through manual
testing.

closes https://github.com/prisma/language-tools/issues/993