### PR TITLE
feat(syntax): add markdown fenced code block highlighting

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -69,6 +69,16 @@
         "embeddedLanguages": {
           "meta.embedded.block.prisma": "prisma"
         }
+      },
+      {
+        "scopeName": "markdown.prisma.codeblock",
+        "path": "./syntaxes/prisma.markdown.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.prisma": "prisma"
+        }
       }
     ],
     "configuration": {

--- a/packages/vscode/syntaxes/prisma.markdown.json
+++ b/packages/vscode/syntaxes/prisma.markdown.json
@@ -1,0 +1,45 @@
+{
+  "fileTypes": [],
+  "injectionSelector": "L:text.html.markdown",
+  "patterns": [
+    {
+      "include": "#prisma-code-block"
+    }
+  ],
+  "repository": {
+    "prisma-code-block": {
+      "name": "markup.fenced_code.block.markdown",
+      "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(prisma)((\\s+|:|,|\\{|\\?)[^`~]*)?$)",
+      "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+      "beginCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        },
+        "4": {
+          "name": "fenced_code.block.language.markdown"
+        },
+        "5": {
+          "name": "fenced_code.block.language.attributes.markdown"
+        }
+      },
+      "endCaptures": {
+        "3": {
+          "name": "punctuation.definition.markdown"
+        }
+      },
+      "patterns": [
+        {
+          "begin": "(^|\\G)(\\s*)(.*)",
+          "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+          "contentName": "meta.embedded.block.prisma",
+          "patterns": [
+            {
+              "include": "source.prisma"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "scopeName": "markdown.prisma.codeblock"
+}

--- a/packages/vscode/syntaxes/prisma.markdown.json
+++ b/packages/vscode/syntaxes/prisma.markdown.json
@@ -3,11 +3,11 @@
   "injectionSelector": "L:text.html.markdown",
   "patterns": [
     {
-      "include": "#prisma-code-block"
+      "include": "#fenced_code_block_prisma"
     }
   ],
   "repository": {
-    "prisma-code-block": {
+    "fenced_code_block_prisma": {
       "name": "markup.fenced_code.block.markdown",
       "begin": "(^|\\G)(\\s*)(`{3,}|~{3,})\\s*(?i:(prisma)((\\s+|:|,|\\{|\\?)[^`~]*)?$)",
       "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",


### PR DESCRIPTION
This PR proposes to add a `prisma.markdown.json` file that adds fenced code block highlighting for Prisma schema syntax in markdown fenced code blocks.

References: https://github.com/microsoft/vscode/blob/main/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json

![image](https://user-images.githubusercontent.com/34304644/160790950-2d9888d9-a720-4c92-91b0-2bc038f5048b.png)
