### PR TITLE
ci: fix e2e tests

### DIFF
--- a/scripts/e2eTestsOnVsix/install_extension.js
+++ b/scripts/e2eTestsOnVsix/install_extension.js
@@ -10,16 +10,14 @@ async function installExtension({ extensionType, extensionVersion }) {
     const extensionName = `Prisma.prisma${vsceArgument}`
 
     // Install VSCode
-    const vscodeExecutablePath = await vscodeTest.downloadAndUnzipVSCode(
-      'stable',
-    )
+    const vscodeExecutablePath = await vscodeTest.downloadAndUnzipVSCode('stable')
 
     // Install VSCode extension
-    const cliPath =
-      vscodeTest.resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath)
+    const [cli, ...args] = vscodeTest.resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath)
+
     const result = childProcess.spawnSync(
-      cliPath,
-      ['--install-extension', `${extensionName}@${extensionVersion}`],
+      cli,
+      [...args, '--install-extension', `${extensionName}@${extensionVersion}`],
       {
         encoding: 'utf-8',
         stdio: 'pipe',


### PR DESCRIPTION
Broken since update dependency @vscode/test-electron to v2
https://github.com/prisma/language-tools/pull/1101

See https://github.com/microsoft/vscode-test