### PR TITLE
ci: extension_version, fail if vsce cmd returns empty version

### DIFF
--- a/scripts/e2eTestsOnVsix/extension_version.sh
+++ b/scripts/e2eTestsOnVsix/extension_version.sh
@@ -2,11 +2,11 @@
 
 set -eu
 
-
-
-
 EXTENSION_INSIDER_VERSION=$(./node_modules/.bin/vsce show Prisma.prisma-insider --json | jq ".versions[0].version" | tr -d '"')
 EXTENSION_STABLE_VERSION=$(./node_modules/.bin/vsce show Prisma.prisma --json | jq ".versions[0].version" | tr -d '"')
+
+[ -z "$EXTENSION_INSIDER_VERSION" ] && echo "EXTENSION_INSIDER_VERSION is undefined, vsce show command failed, see logs." && exit 1
+[ -z "$EXTENSION_STABLE_VERSION" ] && echo "EXTENSION_STABLE_VERSION is undefined, vsce show command failed, see logs." && exit 1
 
 echo "Currently published insider extension version: $EXTENSION_INSIDER_VERSION"
 echo "Currently published stable extension version: $EXTENSION_STABLE_VERSION"

--- a/scripts/e2eTestsOnVsix/extension_version.sh
+++ b/scripts/e2eTestsOnVsix/extension_version.sh
@@ -3,10 +3,19 @@
 set -eu
 
 EXTENSION_INSIDER_VERSION=$(./node_modules/.bin/vsce show Prisma.prisma-insider --json | jq ".versions[0].version" | tr -d '"')
-EXTENSION_STABLE_VERSION=$(./node_modules/.bin/vsce show Prisma.prisma --json | jq ".versions[0].version" | tr -d '"')
+echo "EXTENSION_INSIDER_VERSION: $EXTENSION_INSIDER_VERSION"
 
-[ -z "$EXTENSION_INSIDER_VERSION" ] && echo "EXTENSION_INSIDER_VERSION is undefined, vsce show command failed, see logs." && exit 1
-[ -z "$EXTENSION_STABLE_VERSION" ] && echo "EXTENSION_STABLE_VERSION is undefined, vsce show command failed, see logs." && exit 1
+EXTENSION_STABLE_VERSION=$(./node_modules/.bin/vsce show Prisma.prisma --json | jq ".versions[0].version" | tr -d '"')
+echo "EXTENSION_STABLE_VERSION: $EXTENSION_STABLE_VERSION"
+
+# If env is undefined, log the following and exit
+[ -z "$EXTENSION_INSIDER_VERSION" ] && echo "EXTENSION_INSIDER_VERSION is undefined, vsce show command failed, see logs."
+[ -z "$EXTENSION_STABLE_VERSION" ] && echo "EXTENSION_STABLE_VERSION is undefined, vsce show command failed, see logs."
+
+if [ -z "$EXTENSION_INSIDER_VERSION" ] || [ -z "$EXTENSION_STABLE_VERSION" ]
+then
+  exit 1
+fi
 
 echo "Currently published insider extension version: $EXTENSION_INSIDER_VERSION"
 echo "Currently published stable extension version: $EXTENSION_STABLE_VERSION"


### PR DESCRIPTION
Example: https://github.com/prisma/language-tools/runs/6075506873?check_suite_focus=true#step:6:4

See https://prisma-company.slack.com/archives/C02L83FKUTS/p1650362173763509