### PR TITLE
chore: cleanup givenFieldAttributeParams(): remove '@@index'

### DIFF
--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -2871,13 +2871,12 @@ suite('Completions', function () {
             model Post {
               title      String   @db.VarChar(300)
               abstract   String   @db.VarChar(3000)
-              slug       String   @unique(sort: , length: 42) @db.VarChar(3000)
+              slug       String   @unique(length: 42) @db.VarChar(3000)
               slug2      String   @unique() @db.VarChar(3000)
               author     String
               created_at DateTime
 
               @@index([author, |])
-              @@index([])
             }`,
           expected: {
             isIncomplete: false,
@@ -2899,7 +2898,7 @@ suite('Completions', function () {
             model Post {
               title      String   @db.VarChar(300)
               abstract   String   @db.VarChar(3000)
-              slug       String   @unique(sort: , length: 42) @db.VarChar(3000)
+              slug       String   @unique(length: 42) @db.VarChar(3000)
               slug2      String   @unique() @db.VarChar(3000)
               author     String
               created_at DateTime

--- a/packages/language-server/src/completion/completionUtils.ts
+++ b/packages/language-server/src/completion/completionUtils.ts
@@ -203,7 +203,7 @@ export const sqlServerClusteredValuesCompletionItems: CompletionItem[] = [
 ]
 
 export function givenFieldAttributeParams(
-  fieldAttribute: '@unique' | '@id' | '@@index',
+  fieldAttribute: '@unique' | '@id',
   previewFeatures: PreviewFeatures[] | undefined,
   datasourceProvider: string | undefined,
   wordBeforePosition: string,

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -892,13 +892,6 @@ function getSuggestionsForAttribute(
           datasourceProvider,
           wordBeforePosition,
         )
-      } else if (attribute === '@@index') {
-        fieldAtrributeArguments = givenFieldAttributeParams(
-          '@@index',
-          previewFeatures,
-          datasourceProvider,
-          wordBeforePosition,
-        )
       }
       suggestions = fieldAtrributeArguments
     }


### PR DESCRIPTION
Implemented in `givenBlockAttributeParams()`

It was dead code, logic was
```
if (blockAtrributeArguments.length) {
      suggestions = blockAtrributeArguments
    } else {
	the code removed
    }
```