### PR TITLE
feat(ls): completions for PostgreSQL index types

### DIFF
--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -1219,6 +1219,66 @@ suite('Completions', function () {
             },
           })
         })
+        test('@@index([title(|)]) - postgresql', () => {
+          assertCompletion({
+            provider: 'postgresql',
+            schema: /* Prisma */ `
+        model Type {
+          id    Int @id
+          title   String
+          content String
+          
+          @@index([title(|)])
+        }
+      `,
+            expected: {
+              isIncomplete: false,
+              items: [
+                { label: 'ops', kind: CompletionItemKind.Property },
+                { label: 'sort', kind: CompletionItemKind.Property },
+              ],
+            },
+          })
+        })
+        test('@@index([title(ops: |)]) - postgresql', () => {
+          assertCompletion({
+            provider: 'postgresql',
+            schema: /* Prisma */ `
+        model Type {
+          id    Int @id
+          title   String @db.Inet
+          content String
+          
+          @@index([title(ops: |)])
+        }
+      `,
+            expected: {
+              isIncomplete: false,
+              items: [{ label: 'raw', kind: CompletionItemKind.Function }],
+            },
+          })
+        })
+        test('@@index([title(ops: |)], type: Gist) - postgresql', () => {
+          assertCompletion({
+            provider: 'postgresql',
+            schema: /* Prisma */ `
+        model Type {
+          id    Int @id
+          title   String @db.Inet
+          content String
+          
+          @@index([title(ops: |)], type: Gist)
+        }
+      `,
+            expected: {
+              isIncomplete: false,
+              items: [
+                { label: 'InetOps', kind: CompletionItemKind.Enum },
+                { label: 'raw', kind: CompletionItemKind.Function },
+              ],
+            },
+          })
+        })
       })
     })
 
@@ -2642,7 +2702,6 @@ suite('Completions', function () {
           provider: 'mysql',
           previewFeatures: ['fullTextIndex'],
           schema: /* Prisma */ `
-          
           model Fulltext {
             id      Int    @id
             title   String @db.VarChar(255)
@@ -2651,34 +2710,27 @@ suite('Completions', function () {
             @@fulltext()
             @@fulltext([title, content], )
           }
-          
           model Id {
-            
             id String @id() @db.VarChar(3000)
           }
-          
           model IdWithLength {
             id String @id(length: 100) @db.VarChar(3000)
           }
-          
           model Unique {
             unique Int @unique()
           }
-          
           model CompoundId {
             id_1 String @db.VarChar(3000)
             id_2 String @db.VarChar(3000)
           
             @@id([id_1(length: 100), id_2(length: 10)])
           }
-          
           model CompoundUnique {
             unique_1 Int
             unique_2 Int
           
             @@unique([unique_1(sort: Desc), unique_2])
           }
-          
           model Post {
             title      String   @db.VarChar(300)
             abstract   String   @db.VarChar(3000)
@@ -2712,34 +2764,27 @@ suite('Completions', function () {
             @@fulltext()
             @@fulltext([title, content], )
           }
-          
           model Id {
-            
             id String @id() @db.VarChar(3000)
           }
-          
           model IdWithLength {
             id String @id(length: 100) @db.VarChar(3000)
           }
-          
           model Unique {
             unique Int @unique()
           }
-          
           model CompoundId {
             id_1 String @db.VarChar(3000)
             id_2 String @db.VarChar(3000)
           
             @@id([id_1(length: 100), id_2(length: 10)])
           }
-          
           model CompoundUnique {
             unique_1 Int
             unique_2 Int
           
             @@unique([unique_1(sort: Desc), unique_2])
           }
-          
           model Post {
             title      String   @db.VarChar(300)
             abstract   String   @db.VarChar(3000)

--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -1191,8 +1191,12 @@ suite('Completions', function () {
             expected: {
               isIncomplete: false,
               items: [
-                { label: 'Hash', kind: CompletionItemKind.Enum },
                 { label: 'BTree', kind: CompletionItemKind.Enum },
+                { label: 'Hash', kind: CompletionItemKind.Enum },
+                { label: 'Gist', kind: CompletionItemKind.Enum },
+                { label: 'Gin', kind: CompletionItemKind.Enum },
+                { label: 'SpGist', kind: CompletionItemKind.Enum },
+                { label: 'Brin', kind: CompletionItemKind.Enum },
               ],
             },
           })

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -716,14 +716,30 @@ function getSuggestionsForAttribute(
     if (attribute && attribute !== '@@fulltext' && isInsideAttribute(untrimmedCurrentLine, position, '[]')) {
       if (isInsideFieldArgument(untrimmedCurrentLine, position)) {
         // extendedIndexes
-        return {
-          items: filterSortLengthBasedOnInput(
+        const items: CompletionItem[] = []
+        // https://github.com/prisma/language-tools/issues/1139
+        // https://www.notion.so/prismaio/Proposal-More-PostgreSQL-index-types-GiST-GIN-SP-GiST-and-BRIN-e27ef762ee4846a9a282eec1a5129270
+        if (datasourceProvider === 'postgresql' && attribute === '@@index') {
+          items.push({
+            label: 'ops',
+            insertText: 'ops: $0',
+            kind: CompletionItemKind.Property,
+            documentation: 'Specify the operator class for an indexed field.',
+          })
+        }
+
+        items.push(
+          ...filterSortLengthBasedOnInput(
             attribute,
             previewFeatures,
             datasourceProvider,
             wordBeforePosition,
             sortLengthProperties,
           ),
+        )
+
+        return {
+          items,
           isIncomplete: false,
         }
       }

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -821,43 +821,6 @@ function getSuggestionsForAttribute(
         previewFeatures,
       })
     } else if (attribute === '@@index') {
-      // Auto completion for Hash and BTree for PostgreSQL
-      // includes because `@@index(type: |)` means wordBeforePosition = '@@index(type:'
-      // TODO figure out if we need to add cockroachdb provider here
-      if (
-        datasourceProvider &&
-        ['postgresql', 'postgres'].includes(datasourceProvider) &&
-        wordBeforePosition.includes('type:')
-      ) {
-        // TODO move away
-        const indexTypeCompletionItems: CompletionItem[] = [
-          {
-            label: 'Hash',
-            kind: CompletionItemKind.Enum,
-            insertTextFormat: InsertTextFormat.PlainText,
-            documentation: {
-              kind: 'markdown',
-              value:
-                'The Hash index can perform a faster lookup than a B-Tree index. However, the key downside of the Hash index is that its use is limited to equality operators that will perform matching operations.',
-            },
-          },
-          {
-            label: 'BTree',
-            kind: CompletionItemKind.Enum,
-            insertTextFormat: InsertTextFormat.PlainText,
-            documentation: {
-              kind: 'markdown',
-              value:
-                "The B-tree index is the default, it creates a self-balanced tree, in other words, it sorts itself. It will maintain its balance throughout operations such as insertions, deletions and searches. Using a B-tree index speeds up scan operations because it doesn't have to scan pages or records sequentially in a linear fashion.",
-            },
-          },
-        ]
-        return {
-          items: indexTypeCompletionItems,
-          isIncomplete: false,
-        }
-      }
-
       blockAtrributeArguments = givenBlockAttributeParams({
         blockAttribute: '@@index',
         wordBeforePosition,

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -717,7 +717,6 @@ function getSuggestionsForAttribute(
       if (isInsideFieldArgument(untrimmedCurrentLine, position)) {
         // extendedIndexes
         const items: CompletionItem[] = []
-        // https://github.com/prisma/language-tools/issues/1139
         // https://www.notion.so/prismaio/Proposal-More-PostgreSQL-index-types-GiST-GIN-SP-GiST-and-BRIN-e27ef762ee4846a9a282eec1a5129270
         if (datasourceProvider === 'postgresql' && attribute === '@@index') {
           items.push({


### PR DESCRIPTION
Closes https://github.com/prisma/language-tools/issues/1139

schema for manual testing
```prisma
datasource db {
    provider = "postgresql"
    url      = env("DATABASE_URL")
}

model ops {
    id    Int @id
    title   String
    content String
    
    @@index([title( )], type: Gist)
//                 ^ sort, ops
}

model type {
    id    Int @id
    title   String
    content String
    
    @@index([title], )
//                  ^ fields, map, type
}

model A {
  id  Int    @id
  title String @db.Inet

  @@index([title(ops: )], type: Gist)
//                   ^ See the native type of `title` is `Inet` and
//                     the index type is GiST
//                     it suggests `InetOps` & `raw`.
}

model B {
  id  Int    @id
  title String @db.Inet

  @@index([title], type: )
//                       ^ Gist, Gin, SpGist, Brin, Hash or BTree
}

model C {
    id    Int @id
    title   String
    content String
    
    @@index([title(ops: )], type: Gist)
//                      ^ raw
}
```