### PR TITLE
chore: change min VS Code from 1.52.0 to 1.56.0

### DIFF
--- a/packages/language-server/package-lock.json
+++ b/packages/language-server/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "4.7.4"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "publisher": "Prisma",
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "prisma": {
     "enginesVersion": "95a7e8a9ae520a310e035072616d7da7af3fb847",

--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -17,7 +17,7 @@
       "devDependencies": {
         "@types/glob": "7.2.0",
         "@types/mocha": "9.1.1",
-        "@types/vscode": "1.52.0",
+        "@types/vscode": "1.56.0",
         "@vscode/test-electron": "2.1.5",
         "is-ci": "3.0.1",
         "mocha": "10.0.0",
@@ -26,7 +26,7 @@
         "vsce": "2.10.0"
       },
       "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.56.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -597,9 +597,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
       "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -4766,9 +4766,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
       "dev": true
     },
     "@ungap/promise-all-settled": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "icon": "logo_white.png",
   "engines": {
-    "vscode": "^1.52.0"
+    "vscode": "^1.56.0"
   },
   "publisher": "Prisma",
   "categories": [
@@ -126,7 +126,7 @@
   "devDependencies": {
     "@types/glob": "7.2.0",
     "@types/mocha": "9.1.1",
-    "@types/vscode": "1.52.0",
+    "@types/vscode": "1.56.0",
     "@vscode/test-electron": "2.1.5",
     "is-ci": "3.0.1",
     "mocha": "10.0.0",


### PR DESCRIPTION
https://code.visualstudio.com/updates/v1_56
This is a major Electron release and comes with Chromium 89.0.4389.114 and Node.js 14.16.0.

Also, for language-server: change `engines` for Node.js version from 10 to 14

Related https://github.com/prisma/language-tools/issues/1207