### PR TITLE
feat: Support providing top-level elements as symbols

### DIFF
--- a/packages/language-server/src/__test__/documentSymbol.test.ts
+++ b/packages/language-server/src/__test__/documentSymbol.test.ts
@@ -1,0 +1,162 @@
+import { DocumentSymbol, SymbolKind } from 'vscode-languageserver'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import * as assert from 'assert'
+import { handleDocumentSymbol } from '../MessageHandler'
+import { getTextDocument } from './helper'
+
+function assertSymbols(fixturePath: string, expected: DocumentSymbol[]) {
+  const document: TextDocument = getTextDocument(fixturePath)
+  const actual = handleDocumentSymbol({ textDocument: document }, document)
+  assert.deepStrictEqual(actual, expected)
+}
+
+suite('DocumentSymbol', () => {
+  test('hover.prisma', () => {
+    assertSymbols('./hover.prisma', [
+      {
+        kind: SymbolKind.Interface,
+        name: 'db',
+        range: {
+          end: {
+            character: 1,
+            line: 3,
+          },
+          start: {
+            character: 0,
+            line: 0,
+          },
+        },
+        selectionRange: {
+          end: {
+            character: 13,
+            line: 0,
+          },
+          start: {
+            character: 11,
+            line: 0,
+          },
+        },
+      },
+      {
+        kind: SymbolKind.Function,
+        name: 'client',
+        range: {
+          end: {
+            character: 1,
+            line: 7,
+          },
+          start: {
+            character: 0,
+            line: 5,
+          },
+        },
+        selectionRange: {
+          end: {
+            character: 16,
+            line: 5,
+          },
+          start: {
+            character: 10,
+            line: 5,
+          },
+        },
+      },
+      {
+        kind: SymbolKind.Class,
+        name: 'Post',
+        range: {
+          end: {
+            character: 1,
+            line: 16,
+          },
+          start: {
+            character: 0,
+            line: 10,
+          },
+        },
+        selectionRange: {
+          end: {
+            character: 10,
+            line: 10,
+          },
+          start: {
+            character: 6,
+            line: 10,
+          },
+        },
+      },
+      {
+        kind: SymbolKind.Class,
+        name: 'User',
+        range: {
+          end: {
+            character: 1,
+            line: 26,
+          },
+          start: {
+            character: 0,
+            line: 19,
+          },
+        },
+        selectionRange: {
+          end: {
+            character: 10,
+            line: 19,
+          },
+          start: {
+            character: 6,
+            line: 19,
+          },
+        },
+      },
+      {
+        kind: 10,
+        name: 'UserName',
+        range: {
+          end: {
+            character: 1,
+            line: 32,
+          },
+          start: {
+            character: 0,
+            line: 29,
+          },
+        },
+        selectionRange: {
+          end: {
+            character: 13,
+            line: 29,
+          },
+          start: {
+            character: 5,
+            line: 29,
+          },
+        },
+      },
+      {
+        kind: 10,
+        name: 'Test',
+        range: {
+          end: {
+            character: 1,
+            line: 38,
+          },
+          start: {
+            character: 0,
+            line: 35,
+          },
+        },
+        selectionRange: {
+          end: {
+            character: 9,
+            line: 35,
+          },
+          start: {
+            character: 5,
+            line: 35,
+          },
+        },
+      },
+    ])
+  })
+})

--- a/packages/language-server/src/__test__/jumpToDefinition.test.ts
+++ b/packages/language-server/src/__test__/jumpToDefinition.test.ts
@@ -1,6 +1,6 @@
 import { TextDocument, Position } from 'vscode-languageserver-textdocument'
 import { handleDefinitionRequest } from '../MessageHandler'
-import { Location, Range } from 'vscode-languageserver'
+import { LocationLink, Range } from 'vscode-languageserver'
 import * as assert from 'assert'
 import { getTextDocument } from './helper'
 
@@ -11,10 +11,10 @@ function assertJumpToDefinition(position: Position, expectedRange: Range, fixtur
     textDocument: document,
     position: position,
   }
-  const defResult: Location | undefined = handleDefinitionRequest(document, params)
+  const defResult: LocationLink[] | undefined = handleDefinitionRequest(document, params)
 
   assert.ok(defResult !== undefined)
-  assert.deepStrictEqual(defResult.range, expectedRange)
+  assert.deepStrictEqual(defResult[0].targetRange, expectedRange)
 }
 
 suite('Jump-to-Definition', () => {

--- a/packages/language-server/src/completion/completionUtils.ts
+++ b/packages/language-server/src/completion/completionUtils.ts
@@ -379,13 +379,13 @@ export function removeInvalidAttributeSuggestions(
 ): CompletionItem[] {
   let reachedStartLine = false
   for (const [key, item] of lines.entries()) {
-    if (key === block.start.line + 1) {
+    if (key === block.range.start.line + 1) {
       reachedStartLine = true
     }
     if (!reachedStartLine) {
       continue
     }
-    if (key === block.end.line) {
+    if (key === block.range.end.line) {
       break
     }
 
@@ -414,13 +414,13 @@ export function removeInvalidFieldSuggestions(
 ): string[] {
   let reachedStartLine = false
   for (const [key, item] of lines.entries()) {
-    if (key === block.start.line + 1) {
+    if (key === block.range.start.line + 1) {
       reachedStartLine = true
     }
     if (!reachedStartLine || key === position.line) {
       continue
     }
-    if (key === block.end.line) {
+    if (key === block.range.end.line) {
       break
     }
     const fieldName = item.replace(/ .*/, '')

--- a/packages/language-server/src/rename/renameUtil.ts
+++ b/packages/language-server/src/rename/renameUtil.ts
@@ -39,8 +39,8 @@ export function isValidFieldName(
   if (
     currentBlock.type !== 'model' ||
     // TODO type
-    position.line == currentBlock.start.line ||
-    position.line == currentBlock.end.line
+    position.line == currentBlock.range.start.line ||
+    position.line == currentBlock.range.end.line
   ) {
     return false
   }
@@ -70,7 +70,7 @@ export function isModelName(position: Position, block: Block, lines: string[], d
     return false
   }
 
-  if (position.line === block.start.line) {
+  if (position.line === block.range.start.line) {
     return position.character > 5
   }
 
@@ -78,7 +78,7 @@ export function isModelName(position: Position, block: Block, lines: string[], d
 }
 
 export function isEnumName(position: Position, block: Block, lines: string[], document: TextDocument): boolean {
-  if (block.type === 'enum' && position.line === block.start.line) {
+  if (block.type === 'enum' && position.line === block.range.start.line) {
     return position.character > 4
   }
 
@@ -115,7 +115,7 @@ export function isEnumValue(
 ): boolean {
   return (
     currentBlock.type === 'enum' &&
-    position.line !== currentBlock.start.line &&
+    position.line !== currentBlock.range.start.line &&
     !currentLine.startsWith('@@') &&
     !getWordAtPosition(document, position).startsWith('@')
   )
@@ -163,10 +163,10 @@ function insertMapBlockAttribute(oldName: string, block: Block): TextEdit {
   return {
     range: {
       start: {
-        line: block.end.line,
+        line: block.range.end.line,
         character: 0,
       },
-      end: block.end,
+      end: block.range.end,
     },
     newText: `\t@@map("${oldName}")\n}`,
   }
@@ -176,7 +176,7 @@ function positionIsNotInsideSearchedBlocks(line: number, searchedBlocks: Block[]
   if (searchedBlocks.length === 0) {
     return true
   }
-  return !searchedBlocks.some((block) => line >= block.start.line && line <= block.end.line)
+  return !searchedBlocks.some((block) => line >= block.range.start.line && line <= block.range.end.line)
 }
 
 /**
@@ -198,13 +198,13 @@ export function renameReferencesForFieldValue(
   // search in same model first
   let reachedStartLine = false
   for (const [key, item] of lines.entries()) {
-    if (key === block.start.line + 1) {
+    if (key === block.range.start.line + 1) {
       reachedStartLine = true
     }
     if (!reachedStartLine) {
       continue
     }
-    if (key === block.end.line) {
+    if (key === block.range.end.line) {
       break
     }
     if (item.includes(relationAttribute) && item.includes(currentValue) && !isRelationFieldRename) {
@@ -388,13 +388,13 @@ function mapFieldAttributeExistsAlready(line: string): boolean {
 function mapBlockAttributeExistsAlready(block: Block, lines: string[]): boolean {
   let reachedStartLine = false
   for (const [key, item] of lines.entries()) {
-    if (key === block.start.line + 1) {
+    if (key === block.range.start.line + 1) {
       reachedStartLine = true
     }
     if (!reachedStartLine) {
       continue
     }
-    if (key === block.end.line) {
+    if (key === block.range.end.line) {
       break
     }
     if (item.startsWith('@@map(')) {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -13,6 +13,7 @@ import {
   DocumentFormattingParams,
   DidChangeConfigurationNotification,
   Connection,
+  DocumentSymbolParams,
 } from 'vscode-languageserver'
 import { createConnection, IPCMessageReader, IPCMessageWriter } from 'vscode-languageserver/node'
 import { TextDocument } from 'vscode-languageserver-textdocument'
@@ -77,6 +78,7 @@ export function startServer(options?: LSOptions): void {
         },
         hoverProvider: true,
         renameProvider: true,
+        documentSymbolProvider: true,
       },
     }
 
@@ -213,6 +215,13 @@ export function startServer(options?: LSOptions): void {
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
       return MessageHandler.handleRenameRequest(params, doc)
+    }
+  })
+
+  connection.onDocumentSymbol((params: DocumentSymbolParams) => {
+    const doc = getDocument(params.textDocument.uri)
+    if (doc) {
+      return MessageHandler.handleDocumentSymbol(params, doc)
     }
   })
 


### PR DESCRIPTION
Partially resolves #751, resolves #1031

It only provides top-level symbols (`datasource`, `generator`, `model`, `enum` and `type`), the main usage is to get sticky scroll working:

![image](https://user-images.githubusercontent.com/1330321/184968996-97569ed1-df6a-4d1d-8cfd-220964fe9da6.png)

All supported symbols and their corresponding icons in Outline view:

![image](https://user-images.githubusercontent.com/1330321/184969439-0bbf145f-e907-4926-b8f4-2dc4fb8df417.png)

This PR also changes "Go To Definition" to highlight only the type name, like what TypeScript language server does.

A simple test was added againest the existing `hover.prisma` fixture file.

Providing fields requires much more time to do refactoring, which I don't have now.