### PR TITLE
feat(ls): Autocomplete datasource field "extensions"

### DIFF
--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -220,6 +220,11 @@ suite('Completions', function () {
       label: 'relationMode',
       kind: CompletionItemKind.Field,
     }
+    const fieldPostgresqlExtensions = {
+      label: 'extensions',
+      kind: CompletionItemKind.Field,
+    }
+
     const sqlite = { label: 'sqlite', kind: CompletionItemKind.Constant }
     const mysql = { label: 'mysql', kind: CompletionItemKind.Constant }
     const postgresql = {
@@ -320,6 +325,25 @@ suite('Completions', function () {
         expected: {
           isIncomplete: false,
           items: [envArgument],
+        },
+      })
+    })
+
+    test('Diagnoses field extension availability', () => {
+      assertCompletion({
+        schema: /* Prisma */ `
+          generator client {
+            previewFeatures = ["postgresqlExtensions"]
+          }
+
+          datasource db {
+            provider = "postgresql"
+            |
+          }
+        `,
+        expected: {
+          isIncomplete: false,
+          items: [fieldUrl, fieldShadowDatabaseUrl, fieldRelationMode, fieldPostgresqlExtensions],
         },
       })
     })

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -85,6 +85,11 @@
       "insertText": "relationMode = $0",
       "documentation": "Set the global relation mode for all relations. Values can be either `\"foreignKeys\"` (Default), or `\"prisma\"`. [learn more](https://pris.ly/d/relationMode)",
       "fullSignature": "relationMode = \"foreignKeys\" | \"prisma\")"
+    },
+    {
+      "label": "extensions",
+      "insertText": "extensions = [$0]",
+      "documentation": "Enable PostgreSQL extensions. [Learn More](https://pris.ly/d/postgresql-extensions)"
     }
   ],
   "generatorFields": [

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -262,7 +262,14 @@ export function getSuggestionsForFieldTypes(
 
 function getSuggestionForDataSourceField(block: Block, lines: string[], position: Position): CompletionItem[] {
   // create deep copy
-  const suggestions: CompletionItem[] = klona(supportedDataSourceFields)
+  let suggestions: CompletionItem[] = klona(supportedDataSourceFields)
+
+  const postgresExtensionsEnabled = getAllPreviewFeaturesFromGenerators(lines)?.includes('postgresqlextensions')
+  const isPostgres = getFirstDatasourceProvider(lines)?.includes('postgres')
+
+  if (!(postgresExtensionsEnabled && isPostgres)) {
+    suggestions = suggestions.filter((item) => item.label !== 'extensions')
+  }
 
   const labels: string[] = removeInvalidFieldSuggestions(
     suggestions.map((item) => item.label),
@@ -476,7 +483,6 @@ export function getSuggestionForSupportedFields(
           }
         }
       }
-      break
   }
 
   return {

--- a/packages/language-server/src/previewFeatures.ts
+++ b/packages/language-server/src/previewFeatures.ts
@@ -1,3 +1,3 @@
 export type PreviewFeatures =
   // value must be lowercase
-  Lowercase<'fullTextIndex'>
+  Lowercase<'fullTextIndex'> | Lowercase<'postgresqlExtensions'>


### PR DESCRIPTION
WHEN
```prisma
generator client {
    previewFeatures = ["postgresqlExtensions"]
}

datasource db {
    provider = "postgres(ql)"
    | << "extensions = []"
}
```

closes #1265 