### PR TITLE
nix: use flake-parts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,37 +1,43 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1637014545,
-        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
+        "lastModified": 1668450977,
+        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1637151026,
-        "narHash": "sha256-e2tIMuBKa682J7CkVuMr72K7eCsMDpHpjfhxgxEEggA=",
+        "lastModified": 1669542132,
+        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9bb171cfc786c072cea848c70b31aca0a2dea48b",
+        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
+        "ref": "nixos-unstable",
         "type": "indirect"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,77 +1,25 @@
 {
   description = "An optional nix-based development setup";
 
-  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs = {
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          formatProject = pkgs.writeShellScriptBin "formatProject" ''
-            PATH=${pkgs.nodejs}/bin:${pkgs.jq}/bin:$PATH
-            PRETTIER_VERSION=`jq -r .devDependencies.prettier ${./package.json}`
-            npx prettier@$PRETTIER_VERSION -w ./packages/**/*.ts ./**/*.json ./**/*.js
-          '';
-        in
+  outputs = { self, nixpkgs, flake-parts }:
+    flake-parts.lib.mkFlake { inherit self; } {
+      systems = [ "x86_64-linux" ];
+      perSystem = { pkgs, system, self', ... }:
         {
-          packages = {
-            # Build the vscode extension with pinned dependencies and the local
-            # language server build. It will not package the vscode extension
-            # into a .vsix you can install directly, because this is proving
-            # extremely challenging to do locally.
-            buildVscodeExtension = pkgs.writeShellScriptBin "buildVscodeExtension" ''
-              PATH=${pkgs.nodejs}/bin:${pkgs.jq}/bin:$PATH
-
-              set -euo pipefail
-
-              echo -n 'npm --version: '
-              npm --version
-              echo -n 'node --version: '
-              node --version
-
-              echo 'Deleting node modules...'
-              nix run .#deleteNodeModules
-
-              echo 'Building language-server...'
-              pushd ./packages/language-server
-              npm install
-              npm run build
-              npm prune --production
-              popd
-
-              echo 'Building VSCode extension...'
-              pushd ./packages/vscode
-              npm install
-              npm run build
-              popd
-
-              echo 'ok'
-            '';
-            # Start a VSCode instance with completely default configuration.
-            # Follow the instructions from CONTRIBUTING.md to manually start
-            # another instance of VSCode with the local build of the extension
-            # (unpackaged) locally.
-            code = pkgs.writeShellScriptBin "code" ''
-              TMPDIR=`mktemp -d`
-              USER_DIR=$TMPDIR/user_dir
-              EXTENSIONS_DIR=$TMPDIR/extensions_dir
-              CODE="${pkgs.vscodium}/bin/codium --user-data-dir $USER_DIR --extensions-dir=$EXTENSIONS_DIR"
-
-              mkdir $USER_DIR $EXTENSIONS_DIR
-
-              $CODE . --goto ./packages/vscode/src/__test__/testDb.prisma:10
-            '';
-            deleteNodeModules = pkgs.writeShellScriptBin "deleteNodeModules" ''
-              find . -name 'node_modules' -prune
-              find . -name 'node_modules' -prune | xargs rm -rf
-            '';
-            inherit formatProject;
-          };
-
-          devShell = pkgs.mkShell {
-            packages = [ formatProject pkgs.nodejs self.packages."${system}".buildVscodeExtension self.packages."${system}".deleteNodeModules self.packages."${system}".code ];
-          };
-        }
-      );
+          imports = [
+            ./nix/format-project.nix
+            ./nix/delete-node-modules.nix
+            ./nix/shell.nix
+            ./nix/vscode.nix
+          ];
+        };
+    };
 }

--- a/nix/delete-node-modules.nix
+++ b/nix/delete-node-modules.nix
@@ -1,0 +1,8 @@
+{ pkgs, ... }:
+
+{
+  packages.deleteNodeModules = pkgs.writeShellScriptBin "deleteNodeModules" ''
+    find . -name 'node_modules' -prune
+    find . -name 'node_modules' -prune | xargs rm -rf
+  '';
+}

--- a/nix/format-project.nix
+++ b/nix/format-project.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+
+{
+  packages.formatProject = pkgs.writeShellScriptBin "formatProject" ''
+    PATH=${pkgs.nodejs}/bin:${pkgs.jq}/bin:$PATH
+    PRETTIER_VERSION=`jq -r .devDependencies.prettier ${./package.json}`
+    npx prettier@$PRETTIER_VERSION -w ./packages/**/*.ts ./**/*.json ./**/*.js
+  '';
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,13 @@
+{ pkgs, self', ... }:
+
+{
+  devShells.default = pkgs.mkShell {
+    packages = [
+      pkgs.nodejs
+      self'.packages.buildVscodeExtension
+      self'.packages.code
+      self'.packages.deleteNodeModules
+      self'.packages.formatProject
+    ];
+  };
+}

--- a/nix/vscode.nix
+++ b/nix/vscode.nix
@@ -1,0 +1,52 @@
+{ pkgs, ... }:
+
+{
+  packages = {
+    # Build the vscode extension with pinned dependencies and the local
+    # language server build. It will not package the vscode extension
+    # into a .vsix you can install directly, because this is proving
+    # extremely challenging to do locally.
+    buildVscodeExtension = pkgs.writeShellScriptBin "buildVscodeExtension" ''
+      PATH=${pkgs.nodejs}/bin:${pkgs.jq}/bin:$PATH
+
+      set -euo pipefail
+
+      echo -n 'npm --version: '
+      npm --version
+      echo -n 'node --version: '
+      node --version
+
+      echo 'Deleting node modules...'
+      nix run .#deleteNodeModules
+
+      echo 'Building language-server...'
+      pushd ./packages/language-server
+      npm install
+      npm run build
+      npm prune --production
+      popd
+
+      echo 'Building VSCode extension...'
+      pushd ./packages/vscode
+      npm install
+      npm run build
+      popd
+
+      echo 'ok'
+    '';
+    # Start a VSCode instance with completely default configuration.
+    # Follow the instructions from CONTRIBUTING.md to manually start
+    # another instance of VSCode with the local build of the extension
+    # (unpackaged) locally.
+    code = pkgs.writeShellScriptBin "code" ''
+      TMPDIR=`mktemp -d`
+      USER_DIR=$TMPDIR/user_dir
+      EXTENSIONS_DIR=$TMPDIR/extensions_dir
+      CODE="${pkgs.vscodium}/bin/codium --user-data-dir $USER_DIR --extensions-dir=$EXTENSIONS_DIR"
+
+      mkdir $USER_DIR $EXTENSIONS_DIR
+
+      $CODE . --goto ./packages/vscode/src/__test__/testDb.prisma:10
+    '';
+  };
+}


### PR DESCRIPTION
https://github.com/hercules-ci/flake-parts/

- The library is small, and the main value proposition is the modules system, that many/most nix users are already very familiar with from home-manager/nixos configuration.
- Gluing different projects in a repo together becomes standardized, and not manual like what I had implemented for prisma-fmt-wasm.
- The modules are more composable and easier to isolate in smaller files. We can add more options to the modules if we want.
- The config options are typed and validated.