### PR TITLE
nix: accept arguments in language server wrapper

### DIFF
--- a/nix/prisma-language-server.nix
+++ b/nix/prisma-language-server.nix
@@ -35,9 +35,10 @@ in
         '';
 
         installPhase = ''
+          EXPAND_ARGS='$@'
           mkdir $out/bin
           echo '#!/bin/bash' >> $out/bin/prisma-language-server
-          echo "${nodejs}/bin/node $out/lib/dist/src/bin.js" >> $out/bin/prisma-language-server
+          echo "${nodejs}/bin/node $out/lib/dist/src/bin.js $EXPAND_ARGS" >> $out/bin/prisma-language-server
           chmod +x $out/bin/prisma-language-server
         '';
       };


### PR DESCRIPTION
At first we hardcoded the --stdio argument, then I decided to not do that anymore, and forgot to manually test this. The result is that we can't pass arguments to the language server (mostly --stdio).

This commit fixes that (I tried it, this time).