### PR TITLE
feat: `schemas` completion within datasource

### DIFF
--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -224,6 +224,10 @@ suite('Completions', function () {
       label: 'extensions',
       kind: CompletionItemKind.Field,
     }
+    const fieldSchemas = {
+      label: 'schemas',
+      kind: CompletionItemKind.Field,
+    }
 
     const sqlite = { label: 'sqlite', kind: CompletionItemKind.Constant }
     const mysql = { label: 'mysql', kind: CompletionItemKind.Constant }
@@ -344,6 +348,27 @@ suite('Completions', function () {
         expected: {
           isIncomplete: false,
           items: [fieldUrl, fieldShadowDatabaseUrl, fieldRelationMode, fieldPostgresqlExtensions],
+        },
+      })
+    })
+
+    test('Diagnoses field schemas', () => {
+      assertCompletion({
+        schema: /* Prisma */ `
+          generator client {
+            provider = "prisma-client-js"
+            previewFeatures = ["multiSchema"]
+          }
+
+          datasource db {
+            provider = "cockroachdb"
+            url = env("DATABASE_URL")
+            |
+          }
+        `,
+        expected: {
+          isIncomplete: false,
+          items: [fieldShadowDatabaseUrl, fieldRelationMode, fieldSchemas],
         },
       })
     })

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -90,6 +90,11 @@
       "label": "extensions",
       "insertText": "extensions = [$0]",
       "documentation": "Enable PostgreSQL extensions. [Learn More](https://pris.ly/d/postgresql-extensions)"
+    },
+    {
+      "label": "schemas",
+      "insertText": "schemas = [$0]",
+      "documentation": "The list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)"
     }
   ],
   "generatorFields": [

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -255,7 +255,9 @@ function getSuggestionForDataSourceField(block: Block, lines: string[], position
 
   const isMultiSchemaAvailable = Boolean(
     datasourceProvider &&
-      (datasourceProvider.includes('postgres') || datasourceProvider.includes('cockroach')) &&
+      (datasourceProvider.includes('postgres') ||
+        datasourceProvider.includes('cockroach') ||
+        datasourceProvider.includes('sqlserver')) &&
       previewFeatures?.includes('multischema'),
   )
 

--- a/packages/language-server/src/previewFeatures.ts
+++ b/packages/language-server/src/previewFeatures.ts
@@ -1,3 +1,3 @@
 export type PreviewFeatures =
   // value must be lowercase
-  Lowercase<'fullTextIndex'> | Lowercase<'postgresqlExtensions'>
+  Lowercase<'fullTextIndex'> | Lowercase<'postgresqlExtensions'> | Lowercase<'multiSchema'>


### PR DESCRIPTION
closes https://github.com/prisma/prisma/issues/16920

Workaround until we get we can manage to get these in engines