### PR TITLE
clean(ls): clean up TextDocument usage

### DIFF
--- a/packages/language-server/src/MessageHandler.ts
+++ b/packages/language-server/src/MessageHandler.ts
@@ -36,7 +36,7 @@ import {
   getBlocks,
   MAX_SAFE_VALUE_i32,
 } from './util'
-import { TextDocument } from 'vscode-languageserver-textdocument'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
 import format from './prisma-fmt/format'
 import textDocumentCompletion from './prisma-fmt/textDocumentCompletion'
 import {
@@ -317,7 +317,7 @@ function localCompletions(
         // check if inside attribute
         // Useful to complete composite types
         if (['model', 'view'].includes(foundBlock.type) && isInsideAttribute(currentLineUntrimmed, position, '()')) {
-          return getSuggestionsForInsideRoundBrackets(currentLineUntrimmed, lines, document, position, foundBlock)
+          return getSuggestionsForInsideRoundBrackets(currentLineUntrimmed, lines, position, foundBlock)
         } else {
           return getSuggestionForNativeTypes(foundBlock, lines, wordsBeforePosition, document, onError)
         }
@@ -330,7 +330,7 @@ function localCompletions(
     case 'type':
       // check if inside attribute
       if (isInsideAttribute(currentLineUntrimmed, position, '()')) {
-        return getSuggestionsForInsideRoundBrackets(currentLineUntrimmed, lines, document, position, foundBlock)
+        return getSuggestionsForInsideRoundBrackets(currentLineUntrimmed, lines, position, foundBlock)
       }
       // check if field type
       if (!positionIsAfterFieldAndType(position, document, wordsBeforePosition)) {

--- a/packages/language-server/src/__test__/documentSymbol.test.ts
+++ b/packages/language-server/src/__test__/documentSymbol.test.ts
@@ -1,12 +1,12 @@
 import { DocumentSymbol, SymbolKind } from 'vscode-languageserver'
-import { TextDocument } from 'vscode-languageserver-textdocument'
 import * as assert from 'assert'
 import { handleDocumentSymbol } from '../MessageHandler'
 import { getTextDocument } from './helper'
 
 function assertSymbols(fixturePath: string, expected: DocumentSymbol[]) {
-  const document: TextDocument = getTextDocument(fixturePath)
-  const actual = handleDocumentSymbol({ textDocument: document }, document)
+  const textDocument = getTextDocument(fixturePath)
+  const actual = handleDocumentSymbol({ textDocument }, textDocument)
+
   assert.deepStrictEqual(actual, expected)
 }
 

--- a/packages/language-server/src/__test__/format.test.ts
+++ b/packages/language-server/src/__test__/format.test.ts
@@ -1,20 +1,19 @@
-import { TextDocument } from 'vscode-languageserver-textdocument'
 import { handleDocumentFormatting } from '../MessageHandler'
 import { TextEdit, DocumentFormattingParams } from 'vscode-languageserver'
 import * as assert from 'assert'
 import { getTextDocument } from './helper'
 
 function assertFormat(fixturePath: string): void {
-  const document: TextDocument = getTextDocument(fixturePath)
+  const textDocument = getTextDocument(fixturePath)
   const params: DocumentFormattingParams = {
-    textDocument: document,
+    textDocument,
     options: {
       tabSize: 2,
       insertSpaces: true,
     },
   }
 
-  const formatResult: TextEdit[] = handleDocumentFormatting(params, document)
+  const formatResult: TextEdit[] = handleDocumentFormatting(params, textDocument)
 
   assert.ok(formatResult.length !== 0)
 }

--- a/packages/language-server/src/__test__/hover.test.ts
+++ b/packages/language-server/src/__test__/hover.test.ts
@@ -1,17 +1,17 @@
-import { TextDocument, Position } from 'vscode-languageserver-textdocument'
+import type { Position } from 'vscode-languageserver-textdocument'
 import { handleHoverRequest } from '../MessageHandler'
 import { Hover } from 'vscode-languageserver'
 import * as assert from 'assert'
 import { getTextDocument } from './helper'
 
 function assertHover(position: Position, expected: Hover, fixturePath: string): void {
-  const document: TextDocument = getTextDocument(fixturePath)
+  const textDocument = getTextDocument(fixturePath)
 
   const params = {
-    textDocument: document,
+    textDocument,
     position: position,
   }
-  const hoverResult: Hover | undefined = handleHoverRequest(document, params)
+  const hoverResult: Hover | undefined = handleHoverRequest(textDocument, params)
 
   assert.ok(hoverResult !== undefined)
   assert.deepStrictEqual(hoverResult.contents, expected.contents)

--- a/packages/language-server/src/__test__/jumpToDefinition.test.ts
+++ b/packages/language-server/src/__test__/jumpToDefinition.test.ts
@@ -1,17 +1,14 @@
-import { TextDocument, Position } from 'vscode-languageserver-textdocument'
+import { Position } from 'vscode-languageserver-textdocument'
 import { handleDefinitionRequest } from '../MessageHandler'
 import { LocationLink, Range } from 'vscode-languageserver'
 import * as assert from 'assert'
 import { getTextDocument } from './helper'
 
 function assertJumpToDefinition(position: Position, expectedRange: Range, fixturePath: string): void {
-  const document: TextDocument = getTextDocument(fixturePath)
+  const textDocument = getTextDocument(fixturePath)
 
-  const params = {
-    textDocument: document,
-    position: position,
-  }
-  const defResult: LocationLink[] | undefined = handleDefinitionRequest(document, params)
+  const params = { textDocument, position }
+  const defResult: LocationLink[] | undefined = handleDefinitionRequest(textDocument, params)
 
   assert.ok(defResult !== undefined)
   assert.deepStrictEqual(defResult[0].targetRange, expectedRange)

--- a/packages/language-server/src/__test__/linting.test.ts
+++ b/packages/language-server/src/__test__/linting.test.ts
@@ -1,4 +1,3 @@
-import { TextDocument } from 'vscode-languageserver-textdocument'
 import { handleDiagnosticsRequest } from '../MessageHandler'
 import { Diagnostic, DiagnosticSeverity, DiagnosticTag } from 'vscode-languageserver'
 import * as assert from 'assert'
@@ -6,7 +5,7 @@ import { getTextDocument } from './helper'
 import { MAX_SAFE_VALUE_i32 } from '../util'
 
 function assertLinting(expected: Diagnostic[], fixturePath: string): void {
-  const document: TextDocument = getTextDocument(fixturePath)
+  const document = getTextDocument(fixturePath)
 
   const diagnosticsResults: Diagnostic[] = handleDiagnosticsRequest(document)
 

--- a/packages/language-server/src/__test__/quickFix.test.ts
+++ b/packages/language-server/src/__test__/quickFix.test.ts
@@ -1,4 +1,3 @@
-import { TextDocument } from 'vscode-languageserver-textdocument'
 import { quickFix } from '../codeActionProvider'
 import {
   CodeAction,
@@ -12,12 +11,12 @@ import * as assert from 'assert'
 import { getTextDocument } from './helper'
 
 function assertQuickFix(expected: CodeAction[], fixturePath: string, range: Range, diagnostics: Diagnostic[]): void {
-  const document: TextDocument = getTextDocument(fixturePath)
+  const textDocument = getTextDocument(fixturePath)
 
   const params: CodeActionParams = {
     textDocument: {
       // prisma-fmt expects a URI starting with file:///, if not it will return nothing ([])
-      uri: `file:///${document.uri.substring(2)}`,
+      uri: `file:///${textDocument.uri.substring(2)}`,
     },
     context: {
       diagnostics,
@@ -25,7 +24,7 @@ function assertQuickFix(expected: CodeAction[], fixturePath: string, range: Rang
     range,
   }
 
-  const quickFixResult: CodeAction[] = quickFix(document, params)
+  const quickFixResult: CodeAction[] = quickFix(textDocument, params)
 
   assert.ok(quickFixResult.length !== 0, "Expected a quick fix, but didn't get one")
   assert.deepStrictEqual(quickFixResult, expected)

--- a/packages/language-server/src/__test__/rename.test.ts
+++ b/packages/language-server/src/__test__/rename.test.ts
@@ -1,4 +1,4 @@
-import { TextDocument } from 'vscode-languageserver-textdocument'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
 import { handleRenameRequest } from '../MessageHandler'
 import { WorkspaceEdit, RenameParams, Position } from 'vscode-languageserver'
 import * as assert from 'assert'

--- a/packages/language-server/src/codeActionProvider.ts
+++ b/packages/language-server/src/codeActionProvider.ts
@@ -1,4 +1,4 @@
-import { TextDocument } from 'vscode-languageserver-textdocument'
+import type { TextDocument } from 'vscode-languageserver-textdocument'
 import {
   CodeActionParams,
   CodeAction,

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -1005,7 +1005,6 @@ function getSuggestionsForAttribute({
 export function getSuggestionsForInsideRoundBrackets(
   untrimmedCurrentLine: string,
   lines: string[],
-  document: TextDocument,
   position: Position,
   block: Block,
 ): CompletionList | undefined {

--- a/packages/language-server/src/rename/renameUtil.ts
+++ b/packages/language-server/src/rename/renameUtil.ts
@@ -1,5 +1,5 @@
 import { Position } from 'vscode-languageserver'
-import { TextEdit, TextDocument } from 'vscode-languageserver-textdocument'
+import type { TextEdit, TextDocument } from 'vscode-languageserver-textdocument'
 import {
   Block,
   getCurrentLine,


### PR DESCRIPTION
`TextDocument` in `vscode-languageserver` was marked as deprecated
-> use `vscode-languageserver-textdocument`
-> clean up `TextDocument` imports

closes #1421