### PR TITLE
fix(vscode): ts server restart on file change

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -11,9 +11,10 @@
       "dependencies": {
         "@prisma/language-server": "31.0.2234",
         "checkpoint-client": "1.1.23",
+        "env-paths": "2.2.1",
         "minimatch": "6.2.0",
         "vscode-languageclient": "7.0.0",
-        "watcher": "^1.2.0"
+        "watcher": "1.2.0"
       },
       "devDependencies": {
         "@types/glob": "8.1.0",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -15,9 +15,10 @@
   "dependencies": {
     "@prisma/language-server": "31.0.2234",
     "checkpoint-client": "1.1.23",
+    "env-paths": "2.2.1",
     "minimatch": "6.2.0",
     "vscode-languageclient": "7.0.0",
-    "watcher": "^1.2.0"
+    "watcher": "1.2.0"
   },
   "repository": {
     "type": "git",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -105,12 +105,6 @@
       "type": "object",
       "title": "Prisma",
       "properties": {
-        "prisma.fileWatcher": {
-          "scope": "window",
-          "type": "boolean",
-          "default": true,
-          "description": "Enable/disable the File Watcher functionality for Prisma Client."
-        },
         "prisma.trace.server": {
           "scope": "window",
           "type": "string",
@@ -128,16 +122,6 @@
       {
         "command": "prisma.restartLanguageServer",
         "title": "Restart Language Server",
-        "category": "Prisma"
-      },
-      {
-        "command": "prisma.filewatcherEnable",
-        "title": "Enable the File Watcher functionality for Prisma Client.",
-        "category": "Prisma"
-      },
-      {
-        "command": "prisma.filewatcherDisable",
-        "title": "Disable the File Watcher functionality for Prisma Client.",
         "category": "Prisma"
       }
     ]

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -105,6 +105,12 @@
       "type": "object",
       "title": "Prisma",
       "properties": {
+        "prisma.fileWatcher": {
+          "scope": "window",
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable the File Watcher functionality for Prisma Client."
+        },
         "prisma.trace.server": {
           "scope": "window",
           "type": "string",
@@ -122,6 +128,16 @@
       {
         "command": "prisma.restartLanguageServer",
         "title": "Restart Language Server",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.filewatcherEnable",
+        "title": "Enable the File Watcher functionality for Prisma Client.",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.filewatcherDisable",
+        "title": "Disable the File Watcher functionality for Prisma Client.",
         "category": "Prisma"
       }
     ]

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -82,6 +82,8 @@ function stopGenerateWatcher() {
 
   fileWatcher.close()
   fileWatcher = undefined
+
+  console.log('Stopped watching for changes.')
 }
 
 function setGenerateWatcher(enabled: boolean) {

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -176,20 +176,6 @@ const plugin: PrismaVSCodePlugin = {
 
       /* This command is part of the workaround for https://github.com/prisma/language-tools/issues/311 */
       commands.registerCommand('prisma.applySnippetWorkspaceEdit', applySnippetWorkspaceEdit()),
-
-      commands.registerCommand('prisma.filewatcherEnable', async () => {
-        const prismaConfig = workspace.getConfiguration('prisma')
-        // First, is set to true value
-        // Second, is set it on Workspace level settings
-        await prismaConfig.update('fileWatcher', true, false)
-      }),
-
-      commands.registerCommand('prisma.filewatcherDisable', async () => {
-        const prismaConfig = workspace.getConfiguration('prisma')
-        // First, is set to false value
-        // Second, is set it on Workspace level settings
-        await prismaConfig.update('fileWatcher', false, false)
-      }),
     )
 
     activateClient(context, serverOptions, clientOptions)

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -188,12 +188,14 @@ const plugin: PrismaVSCodePlugin = {
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
 
-    // when the file watcher settings change, we need to ensure they are applied
-    workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('prisma.fileWatcher')) {
-        setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
-      }
-    })
+    context.subscriptions.push(
+      // when the file watcher settings change, we need to ensure they are applied
+      workspace.onDidChangeConfiguration((event) => {
+        if (event.affectsConfiguration('prisma.fileWatcher')) {
+          setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
+        }
+      }),
+    )
 
     context.subscriptions.push(
       commands.registerCommand('prisma.restartLanguageServer', async () => {

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -62,7 +62,7 @@ const onFileChange = (filepath: string) => {
 }
 
 const startGenerateWatcher = () => {
-  const prismaCache = paths('prisma', { suffix: '' }).cache
+  const prismaCache = paths('checkpoint').cache
   const signalsPath = path.join(prismaCache, 'last-generate')
   const fwOptions = { debounce: 500, ignoreInitial: true }
   const fw = new FileWatcher(signalsPath, fwOptions)

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -93,14 +93,8 @@ const startFileWatcher = (rootPath: string) => {
       if (!targetPath.startsWith(rootPath)) return true
       if (targetPath.endsWith('.git')) return true
 
-      // for all the sub-directories of the project, allow recursion into node_modules
-      if (fs.statSync(targetPath).isDirectory() && !targetPath.includes('node_modules')) {
-        allowedWatcherPaths[path.join(targetPath, 'node_modules')] = true
-        return false
-      }
-
-      // but every time we hit a project path, we ensure some sub-paths are whitelisted
-      if (fs.statSync(targetPath).isDirectory()) {
+      // every time we hit a project path, ensure some sub-paths are whitelisted
+      if (!(targetPath in allowedWatcherPaths) && fs.statSync(targetPath).isDirectory()) {
         try {
           // we get the location of installation of the @prisma/client package
           const clientPath = path.dirname(require.resolve('@prisma/client', { paths: [targetPath] }))

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -99,8 +99,8 @@ const startFileWatcher = (rootPath: string) => {
         return false
       }
 
-      // but every time we hit a node_module path, ensure some sub-paths are whitelisted
-      if (fs.statSync(targetPath).isDirectory() && targetPath.endsWith('node_modules')) {
+      // but every time we hit a project path, we ensure some sub-paths are whitelisted
+      if (fs.statSync(targetPath).isDirectory()) {
         try {
           // we get the location of installation of the @prisma/client package
           const clientPath = path.dirname(require.resolve('@prisma/client', { paths: [targetPath] }))
@@ -124,10 +124,7 @@ const startFileWatcher = (rootPath: string) => {
         }
       }
 
-      // if the path is in the allowed paths then we don't ignore it
-      if (targetPath in allowedWatcherPaths) {
-        return false
-      }
+      if (targetPath in allowedWatcherPaths) return false
 
       return true
     },

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -195,9 +195,7 @@ const plugin: PrismaVSCodePlugin = {
           setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
         }
       }),
-    )
 
-    context.subscriptions.push(
       commands.registerCommand('prisma.restartLanguageServer', async () => {
         client = await restartClient(context, client, serverOptions, clientOptions)
         window.showInformationMessage('Prisma language server restarted.') // eslint-disable-line @typescript-eslint/no-floating-promises

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -10,7 +10,6 @@ import {
   Range,
   TextDocument,
   window,
-  workspace,
 } from 'vscode'
 import {
   CodeAction as lsCodeAction,

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -188,6 +188,13 @@ const plugin: PrismaVSCodePlugin = {
       } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     }
 
+    // when the file watcher settings change, we need to ensure they are applied
+    workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('prisma.fileWatcher')) {
+        setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
+      }
+    })
+
     context.subscriptions.push(
       commands.registerCommand('prisma.restartLanguageServer', async () => {
         client = await restartClient(context, client, serverOptions, clientOptions)
@@ -207,12 +214,6 @@ const plugin: PrismaVSCodePlugin = {
         await prismaConfig.update('fileWatcher', false /* value */, false /* workspace */)
       }),
     )
-
-    workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('prisma.fileWatcher')) {
-        setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
-      }
-    })
 
     activateClient(context, serverOptions, clientOptions)
 


### PR DESCRIPTION
This PR works with https://github.com/prisma/prisma/pull/19457, we now send a simpler signal for when we need to reload types via our extension, instead of watching many possible paths.

closes https://github.com/prisma/prisma/issues/13946