### PR TITLE
fix(ls): `handleDefinitionRequest` fails to locate the correct block when multiple names are present within the same block (issue #1247)

### DIFF
--- a/packages/language-server/src/MessageHandler.ts
+++ b/packages/language-server/src/MessageHandler.ts
@@ -166,7 +166,7 @@ export function handleDefinitionRequest(document: TextDocument, params: Declarat
   const foundBlocks: Block[] = results
     .map((result) => {
       const block = getBlockAtPosition(result, lines)
-      if (block && block.name === word) {
+      if (block && block.name === word && block.range.start.line === result) {
         return block
       }
     })


### PR DESCRIPTION
Based on @Druue  's [comment](https://github.com/prisma/language-tools/issues/1247#issuecomment-1344111645), I have identified the bug.

The issue lies in the implementation of `handleDefinitionRequest` within `MessageHandler.ts`. It currently employs a workaround to determine the starting position of all potential blocks. However, the criterion used does not correctly identify lines that are actually fields within a block. To address this, I propose a simple fix: filtering out any matches that is not found by the start line of a block.


I have tested this fix and it works perfectly for the following cases:

1. Original case from #1247
```
enum PostType {
  A
  B
}

model Post {
  id   String   @id
  type PostType

  userId String
  user   User   @relation(fields: [userId], references: [id])
}

model User {
  id String @id

  posts Post[]
}
```

2. Another minimal reproducible example
```
model Post {
  id String @id
  x  String // type of Post

  userId String
  user   User   @relation(fields: [userId], references: [id])
}

model User {
  id String @id

  posts Post[]
}
```

3. Commenting out the line `type PostType` previously did not work, but now it works as expected:
```
enum PostType {
  A
  B
}

model Post {
  id   String   @id
  // type PostType

  userId String
  user   User   @relation(fields: [userId], references: [id])
}

model User {
  id String @id

  posts Post[]
}
```

Please let me know if there is anything else I can assist you with!

closes #1247 