### PR TITLE
fix: show stacktrace from wasm in logs

### DIFF
--- a/packages/language-server/src/prisma-schema-wasm/util.ts
+++ b/packages/language-server/src/prisma-schema-wasm/util.ts
@@ -36,27 +36,27 @@ export function getCliVersion(): string {
 export function handleWasmError(e: Error, cmd: string, onError?: (errorMessage: string) => void) {
   const getErrorMessage = () => {
     if (isWasmPanic(e)) {
-      const { message } = getWasmError(e)
+      const { message, stack } = getWasmError(e)
       const msg = `prisma-schema-wasm errored when invoking ${cmd}. It resulted in a Wasm panic.\n${message}`
-
-      return { message: msg, isPanic: true }
+      return { message: msg, isPanic: true, stack }
     }
 
     const msg = `prisma-schema-wasm errored when invoking ${cmd}.\n${e.message}`
-    return { message: msg, isPanic: false }
+    return { message: msg, isPanic: false, stack: e.stack }
   }
 
-  const { message, isPanic } = getErrorMessage()
+  const { message, isPanic, stack } = getErrorMessage()
 
   if (isPanic) {
-    console.error(message)
+    console.warn(`prisma-schema-wasm errored (panic) with: ${message}\n\n${stack}`)
   } else {
-    console.warn(message)
+    console.warn(`prisma-schema-wasm errored with: ${message}\n\n${stack}`)
   }
 
   if (onError) {
     onError(
-      "prisma-schema-wasm errored. To get a more detailed output please see Prisma Language Server output. You can do this by going to View, then Output from the toolbar, and then select 'Prisma Language Server' in the drop-down menu.",
+      // Note: VS Code strips newline characters from the message
+      `prisma-schema-wasm errored with: -- ${message} -- For the full output check the "Prisma Language Server" output. In the menu, click View, then Output and select 'Prisma Language Server' in the drop-down menu.`,
     )
   }
 }

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -144,7 +144,8 @@ export function startServer(options?: LSOptions): void {
   //   return result
   // }
 
-  function showErrorToast(errorMessage: string) {
+  // Note: VS Code strips newline characters from the message
+  function showErrorToast(errorMessage: string): void {
     connection.window.showErrorMessage(errorMessage)
   }
 


### PR DESCRIPTION
Triggered by https://github.com/prisma/language-tools/issues/1466

<img width="435" alt="Screenshot 2023-07-26 at 13 04 37" src="https://github.com/prisma/language-tools/assets/1328733/329874d2-9732-4ef1-a471-ea4b5cd84724">
<img width="589" alt="Screenshot 2023-07-26 at 13 18 44" src="https://github.com/prisma/language-tools/assets/1328733/71d89da9-2dd1-4b99-bc3c-d680a7672f28">
