### PR TITLE
fix(vscode): also activate extension for .js(x) .ts(x)

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -34,7 +34,11 @@
   },
   "main": "./dist/src/extension.js",
   "activationEvents": [
-    "onLanguage:prisma"
+    "onLanguage:prisma",
+    "onLanguage:javascript",
+    "onLanguage:javascriptreact",
+    "onLanguage:typescript",
+    "onLanguage:typescriptreact"
   ],
   "contributes": {
     "languages": [


### PR DESCRIPTION
Previously the extension would only activate once a `.prisma` file was open.