### PR TITLE
@pls-ignore keyword to suppress lint errors

### DIFF
--- a/packages/language-server/src/prisma-schema-wasm/lint.ts
+++ b/packages/language-server/src/prisma-schema-wasm/lint.ts
@@ -19,8 +19,17 @@ export default function lint(text: string, onError?: (errorMessage: string) => v
     }
 
     const result = prismaSchemaWasm.lint(text)
-
-    return JSON.parse(result) as LinterError[]
+    const errors = JSON.parse(result) as LinterError[]
+    return errors.filter((error) => {
+      try {
+        const lastNewLine = text.substring(0, error.start).lastIndexOf('\n')
+        const nextNewLine = error.end + text.substring(error.end).indexOf('\n')
+        const lineOfCode = text.substring(lastNewLine, nextNewLine)
+        return !/\/\/\s*@pls-ignore/.test(lineOfCode)
+      } catch (_e) {
+        return true
+      }
+    })
   } catch (e) {
     const err = e as Error
 


### PR DESCRIPTION
If an errant line of code out of linter includes `// @pls-ignore` it'll be discarded and not reported 

closes #1491 