### PR TITLE
fix(completion): remove engineType=dataproxy

### DIFF
--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -589,10 +589,6 @@ suite('Completions', function () {
               label: 'binary',
               kind: CompletionItemKind.Constant,
             },
-            {
-              label: 'dataproxy',
-              kind: CompletionItemKind.Constant,
-            },
           ],
         },
       })

--- a/packages/language-server/src/completion/completions.json
+++ b/packages/language-server/src/completion/completions.json
@@ -403,10 +403,6 @@
     {
       "label": "binary",
       "documentation": "Executable binary."
-    },
-    {
-      "label": "dataproxy",
-      "documentation": "Prisma Data Proxy."
     }
   ],
   "engineTypeArguments": [


### PR DESCRIPTION
Not used anymore since https://github.com/prisma/prisma/releases/tag/5.2.0 

See https://github.com/prisma/prisma/pull/20692