### PR TITLE
fix(LS): offer composite types as field type completions

### DIFF
--- a/packages/language-server/src/__test__/completion.test.ts
+++ b/packages/language-server/src/__test__/completion.test.ts
@@ -1807,7 +1807,7 @@ suite('Completions', function () {
         },
       })
     })
-    // TODO should suggest `MyType`?
+
     test('Diagnoses type suggestions in model - MongoDB', () => {
       assertCompletion({
         provider: 'mongodb',
@@ -1844,6 +1844,7 @@ suite('Completions', function () {
             { label: 'Post', kind: CompletionItemKind.Reference },
             { label: 'PostType', kind: CompletionItemKind.Reference },
             { label: 'Something', kind: CompletionItemKind.Reference },
+            { label: 'MyType', kind: CompletionItemKind.Reference },
           ],
         },
       })

--- a/packages/language-server/src/codeActionProvider.ts
+++ b/packages/language-server/src/codeActionProvider.ts
@@ -8,7 +8,7 @@ import {
   Range,
 } from 'vscode-languageserver'
 import levenshtein from 'js-levenshtein'
-import { convertDocumentTextToTrimmedLineArray, getAllRelationNames } from './util'
+import { convertDocumentTextToTrimmedLineArray, getAllRelationNames, relationNamesRegexFilter } from './util'
 import codeActions from './prisma-schema-wasm/codeActions'
 
 function getInsertRange(document: TextDocument): Range {
@@ -110,7 +110,7 @@ export function quickFix(
       const hasTypeModifierOptional: boolean = diagText.endsWith('?')
       diagText = removeTypeModifiers(hasTypeModifierArray, hasTypeModifierOptional, diagText)
       const lines: string[] = convertDocumentTextToTrimmedLineArray(textDocument)
-      const spellingSuggestion = getSpellingSuggestions(diagText, getAllRelationNames(lines))
+      const spellingSuggestion = getSpellingSuggestions(diagText, getAllRelationNames(lines, relationNamesRegexFilter))
       if (spellingSuggestion) {
         codeActionList.push({
           title: `Change spelling to '${spellingSuggestion}'`,

--- a/packages/language-server/src/completion/completions.ts
+++ b/packages/language-server/src/completion/completions.ts
@@ -52,6 +52,8 @@ import {
   getFieldTypesFromCurrentBlock,
   getValuesInsideSquareBrackets,
   getCompositeTypeFieldsRecursively,
+  relationNamesRegexFilter,
+  relationNamesMongoDBRegexFilter,
 } from '../util'
 
 const getSuggestionForBlockAttribute = (
@@ -239,7 +241,10 @@ export function getSuggestionsForFieldTypes(
 
   if (foundBlock instanceof Block) {
     // get all model names
-    const modelNames: string[] = getAllRelationNames(lines)
+    const modelNames: string[] =
+      datasourceProvider === 'mongodb'
+        ? getAllRelationNames(lines, relationNamesMongoDBRegexFilter)
+        : getAllRelationNames(lines, relationNamesRegexFilter)
     suggestions.push(...toCompletionItems(modelNames, CompletionItemKind.Reference))
   }
 

--- a/packages/language-server/src/rename/renameUtil.ts
+++ b/packages/language-server/src/rename/renameUtil.ts
@@ -11,6 +11,7 @@ import {
   extractFirstWord,
   MAX_SAFE_VALUE_i32,
   BlockType,
+  relationNamesRegexFilter,
 } from '../util'
 
 function getType(currentLine: string): string {
@@ -22,7 +23,7 @@ function getType(currentLine: string): string {
 }
 
 export function isRelationField(currentLine: string, lines: string[]): boolean {
-  const relationNames = getAllRelationNames(lines)
+  const relationNames = getAllRelationNames(lines, relationNamesRegexFilter)
   const type = getType(currentLine)
 
   if (type == '') {
@@ -109,7 +110,7 @@ function renameModelOrEnumWhereUsedAsType(
     return false
   }
 
-  const allRelationNames: string[] = getAllRelationNames(lines)
+  const allRelationNames: string[] = getAllRelationNames(lines, relationNamesRegexFilter)
   const currentName = getWordAtPosition(document, position)
   const isRelation = allRelationNames.includes(currentName)
   if (!isRelation) {

--- a/packages/language-server/src/util.ts
+++ b/packages/language-server/src/util.ts
@@ -3,6 +3,10 @@ import { Position, Range } from 'vscode-languageserver'
 import nativeTypeConstructors, { NativeTypeConstructors } from './prisma-schema-wasm/nativeTypes'
 import { PreviewFeatures } from './previewFeatures'
 
+export const relationNamesRegexFilter = /^(model|enum|view)\s+(\w+)\s+{/gm
+
+export const relationNamesMongoDBRegexFilter = /^(model|enum|view|type)\s+(\w+)\s+{/gm
+
 export type BlockType = 'generator' | 'datasource' | 'model' | 'type' | 'enum' | 'view'
 
 export class Block {
@@ -243,11 +247,10 @@ export function extractBlockName(line: string): string {
   return line.slice(blockType.length, line.length - 1).trim()
 }
 
-export function getAllRelationNames(lines: string[]): string[] {
+export function getAllRelationNames(lines: string[], regexFilter: RegExp): string[] {
   const modelNames: string[] = []
   for (const line of lines) {
-    const modelOrEnumRegex = /^(model|enum|view)\s+(\w+)\s+{/gm
-    const result = modelOrEnumRegex.exec(line)
+    const result = regexFilter.exec(line)
     if (result && result[2]) {
       modelNames.push(result[2])
     }


### PR DESCRIPTION
- Updated getAllRelationNames to be able to take different regex filters.
- Updated completions to offer composite types as field type completions.

fixes #1495