### PR TITLE
fix(vc): bigint to be recognised as a scalar field and use that colour

### DIFF
--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -150,7 +150,7 @@
       "name": "scalar.field",
       "patterns": [
         {
-          "match": "^\\s*(\\w+)(\\s*:)?\\s+((?!(?:Int|String|DateTime|Bytes|Decimal|Float|Json|Boolean)\\b)\\b\\w+)?(Int|String|DateTime|Bytes|Decimal|Float|Json|Boolean)?(\\[\\])?(\\?)?(\\!)?",
+          "match": "^\\s*(\\w+)(\\s*:)?\\s+((?!(?:Int|BigInt|String|DateTime|Bytes|Decimal|Float|Json|Boolean)\\b)\\b\\w+)?(Int|BigInt|String|DateTime|Bytes|Decimal|Float|Json|Boolean)?(\\[\\])?(\\?)?(\\!)?",
           "captures": {
             "1": {
               "name": "variable.other.assignment.prisma"


### PR DESCRIPTION
![image](https://github.com/prisma/language-tools/assets/29753584/b6fb27b6-942e-40eb-945b-9ed7d8f231f2)
![image](https://github.com/prisma/language-tools/assets/29753584/f8d49441-d29d-46cf-be0c-e40e4d3a6e6b)
