### PR TITLE
fix(ls): support multiline comments in hover

### DIFF
--- a/packages/language-server/src/MessageHandler.ts
+++ b/packages/language-server/src/MessageHandler.ts
@@ -34,7 +34,7 @@ import {
   isInsideAttribute,
   getSymbolBeforePosition,
   getBlocks,
-  MAX_SAFE_VALUE_i32,
+  getDocumentationForBlock,
 } from './util'
 import type { TextDocument } from 'vscode-languageserver-textdocument'
 import format from './prisma-schema-wasm/format'
@@ -213,21 +213,19 @@ export function handleHoverRequest(document: TextDocument, params: HoverParams):
     return
   }
 
-  const foundBlock = getModelOrTypeOrEnumOrViewBlock(word, lines)
-  if (!foundBlock) {
+  const block = getModelOrTypeOrEnumOrViewBlock(word, lines)
+  if (!block) {
     return
   }
 
-  const commentLine = foundBlock.range.start.line - 1
-  const docComments = document.getText({
-    start: { line: commentLine, character: 0 },
-    end: { line: commentLine, character: MAX_SAFE_VALUE_i32 },
-  })
-  if (docComments.startsWith('///')) {
+  const blockDocumentation = getDocumentationForBlock(document, block)
+
+  if (blockDocumentation.length !== 0) {
     return {
-      contents: docComments.slice(4).trim(),
+      contents: blockDocumentation.join('\n\n'),
     }
   }
+
   // TODO uncomment once https://github.com/prisma/prisma/issues/2546 is resolved!
   /*if (docComments.startsWith('//')) {
     return {

--- a/packages/language-server/src/__test__/documentSymbol.test.ts
+++ b/packages/language-server/src/__test__/documentSymbol.test.ts
@@ -67,21 +67,21 @@ suite('DocumentSymbol', () => {
         range: {
           end: {
             character: 1,
-            line: 16,
+            line: 17,
           },
           start: {
             character: 0,
-            line: 10,
+            line: 11,
           },
         },
         selectionRange: {
           end: {
             character: 10,
-            line: 10,
+            line: 11,
           },
           start: {
             character: 6,
-            line: 10,
+            line: 11,
           },
         },
       },
@@ -91,21 +91,21 @@ suite('DocumentSymbol', () => {
         range: {
           end: {
             character: 1,
-            line: 26,
+            line: 27,
           },
           start: {
             character: 0,
-            line: 19,
+            line: 20,
           },
         },
         selectionRange: {
           end: {
             character: 10,
-            line: 19,
+            line: 20,
           },
           start: {
             character: 6,
-            line: 19,
+            line: 20,
           },
         },
       },
@@ -115,21 +115,21 @@ suite('DocumentSymbol', () => {
         range: {
           end: {
             character: 1,
-            line: 32,
+            line: 33,
           },
           start: {
             character: 0,
-            line: 29,
+            line: 30,
           },
         },
         selectionRange: {
           end: {
             character: 13,
-            line: 29,
+            line: 30,
           },
           start: {
             character: 5,
-            line: 29,
+            line: 30,
           },
         },
       },
@@ -139,21 +139,21 @@ suite('DocumentSymbol', () => {
         range: {
           end: {
             character: 1,
-            line: 38,
+            line: 39,
           },
           start: {
             character: 0,
-            line: 35,
+            line: 36,
           },
         },
         selectionRange: {
           end: {
             character: 9,
-            line: 35,
+            line: 36,
           },
           start: {
             character: 5,
-            line: 35,
+            line: 36,
           },
         },
       },

--- a/packages/language-server/src/__test__/hover.test.ts
+++ b/packages/language-server/src/__test__/hover.test.ts
@@ -24,11 +24,11 @@ suite('Hover of /// documentation comments', () => {
   test('Model', () => {
     assertHover(
       {
-        character: 10,
-        line: 23,
+        character: 15,
+        line: 24,
       },
       {
-        contents: 'Post including an author and content.',
+        contents: "Post including an author, it's content\n\nand whether it was published",
       },
       fixturePath,
     )
@@ -36,8 +36,8 @@ suite('Hover of /// documentation comments', () => {
   test('Enum', () => {
     assertHover(
       {
-        character: 17,
-        line: 24,
+        character: 15,
+        line: 25,
       },
       {
         contents: 'This is an enum specifying the UserName.',

--- a/packages/language-server/src/util.ts
+++ b/packages/language-server/src/util.ts
@@ -541,4 +541,22 @@ export function getCompositeTypeFieldsRecursively(
   }
 }
 
+export const getDocumentationForBlock = (document: TextDocument, block: Block): string[] => {
+  return getDocumentation(document, block.range.start.line, [])
+}
+
+const getDocumentation = (document: TextDocument, line: number, comments: string[]): string[] => {
+  const comment = document.getText({
+    start: { line: line - 1, character: 0 },
+    end: { line: line - 1, character: MAX_SAFE_VALUE_i32 },
+  })
+
+  if (comment.startsWith('///')) {
+    comments.unshift(comment.slice(4).trim())
+
+    return getDocumentation(document, line - 1, comments)
+  }
+  return comments
+}
+
 export const MAX_SAFE_VALUE_i32 = 2147483647

--- a/packages/language-server/test/fixtures/hover_postgresql.prisma
+++ b/packages/language-server/test/fixtures/hover_postgresql.prisma
@@ -7,29 +7,30 @@ generator client {
   provider = "prisma-client-js"
 }
 
-/// Post including an author and content.
+/// Post including an author, it's content
+/// and whether it was published
 model Post {
-  id        Int         @default(autoincrement()) @id
+  id        Int     @id @default(autoincrement())
   content   String?
-  published Boolean     @default(false)
-  author    User?       @relation(fields: [authorId], references: [id])
+  published Boolean @default(false)
+  author    User?   @relation(fields: [authorId], references: [id])
   authorId  Int?
 }
 
 // Documentation for this model.
 model User {
-  id    Int     @default(autoincrement()) @id
-  email String  @unique
-  name  String?
-  posts Post[]
+  id          Int      @id @default(autoincrement())
+  email       String   @unique
+  name        String?
+  posts       Post[]
   specialName UserName
-  test Test
+  test        Test
 }
 
 /// This is an enum specifying the UserName.
 enum UserName {
-    Fred
-    Eric
+  Fred
+  Eric
 }
 
 // This is a test enum.


### PR DESCRIPTION
<img width="724" alt="image" src="https://github.com/prisma/language-tools/assets/29753584/538de72b-bcbe-4613-b07c-11ceb1ba423d">

fix #861