### PR TITLE
ci: switch from Node.js 16 to 18

### DIFF
--- a/.github/workflows/1_2_b_bump_extension_only.yml
+++ b/.github/workflows/1_2_b_bump_extension_only.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install && npm run bootstrap

--- a/.github/workflows/1_2_c_promote_patch_to_stable.yml
+++ b/.github/workflows/1_2_c_promote_patch_to_stable.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install && npm run bootstrap

--- a/.github/workflows/1_check_for_updates.yml
+++ b/.github/workflows/1_check_for_updates.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/2_bump_versions.yml
+++ b/.github/workflows/2_bump_versions.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install && npm run bootstrap

--- a/.github/workflows/3_LS_tests_publish.yml
+++ b/.github/workflows/3_LS_tests_publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install && npm run bootstrap
@@ -56,7 +56,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
           # Setup .npmrc file to publish to npm
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/4_bump_LS_in_extension.yml
+++ b/.github/workflows/4_bump_LS_in_extension.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Print inputs
         run: |
           echo ${{github.event.inputs.npm_channel}}

--- a/.github/workflows/5_e2e_tests.yml
+++ b/.github/workflows/5_e2e_tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Install Dependencies
         run: npm install && npm run bootstrap
       - name: Compile
@@ -56,7 +56,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Print inputs
         run: |
           echo ${{github.event.inputs.npm_channel}}

--- a/.github/workflows/6_build.yml
+++ b/.github/workflows/6_build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Print inputs
         run: |

--- a/.github/workflows/7_publish.yml
+++ b/.github/workflows/7_publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Print inputs
         run: |
@@ -87,7 +87,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Print inputs
         run: |

--- a/.github/workflows/PR_build_extension.yml
+++ b/.github/workflows/PR_build_extension.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
 
       # Build the extension

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install && npm run bootstrap

--- a/.github/workflows/e2e_check_for_new_published_vsix.yml
+++ b/.github/workflows/e2e_check_for_new_published_vsix.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install

--- a/.github/workflows/e2e_published_vsix.yml
+++ b/.github/workflows/e2e_published_vsix.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'npm'
       - name: Install Dependencies
         run: npm install && npm run bootstrap


### PR DESCRIPTION
Since Node.js 16 is EOL for a while already, tooling does not support it anymore.

Example: ovsx failed to publish 5.12.0 yesterday -> https://github.com/prisma/language-tools/actions/runs/8523249444/job/23345119163#step:8:12
```
 ovsx requires at least NodeJS version 18. Check your installed version with `node --version`.
```
Renovate PR for the update:
https://github.com/prisma/language-tools/pull/1692

This will not change our confidence regarding supporting old versions of VS Code since we test the oldest one we support in https://github.com/prisma/language-tools/blob/0528403aafa98820d003e194d94d69d1f4a133b4/packages/vscode/src/__test__/runTest.ts#L43-L46