### PR TITLE
feat(vscode): Add codelens provider w/ generate client command

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -138,6 +138,13 @@
             "yarn"
           ],
           "default": "npx"
+        },
+        "prisma.schemaPath": {
+          "type": "string",
+          "examples": [
+            "/path/to/your/schema.prisma"
+          ],
+          "description": "If you have a Prisma schema file in a custom path, you will need to provide said path `/path/to/your/schema.prisma` to run generate"
         }
       }
     },
@@ -165,6 +172,11 @@
       {
         "command": "prisma.disableCodeLens",
         "title": "Disable Codelens",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.generate",
+        "title": "Generate",
         "category": "Prisma"
       }
     ]

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -125,6 +125,19 @@
           ],
           "default": "off",
           "description": "Setting for logging between the VS Code extension and the language server."
+        },
+        "prisma.enableCodeLens": {
+          "type": "boolean",
+          "default": true
+        },
+        "prisma.scriptRunner": {
+          "type": "string",
+          "enum": [
+            "npx",
+            "pnpm",
+            "yarn"
+          ],
+          "default": "npx"
         }
       }
     },
@@ -142,6 +155,16 @@
       {
         "command": "prisma.filewatcherDisable",
         "title": "Disable the File Watcher functionality for Prisma Client.",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.enableCodeLens",
+        "title": "Enable CodeLens",
+        "category": "Prisma"
+      },
+      {
+        "command": "prisma.disableCodeLens",
+        "title": "Disable Codelens",
         "category": "Prisma"
       }
     ]

--- a/packages/vscode/src/CodeLensProvider.ts
+++ b/packages/vscode/src/CodeLensProvider.ts
@@ -12,7 +12,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
   public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event
 
   constructor() {
-    this.generatorRegex = /(generator [a-zA-Z]+ {)/g
+    this.generatorRegex = /(generator +[a-zA-Z0-9]+ +{)/g
     this.enabled = vscode.workspace.getConfiguration('prisma').get('enableCodeLens', true)
 
     vscode.workspace.onDidChangeConfiguration((_) => {
@@ -37,7 +37,7 @@ export class CodelensProvider implements vscode.CodeLensProvider {
         new vscode.CodeLens(range, {
           title: 'Generate',
           command: 'prisma.generate',
-          tooltip: `Codelens to run Prisma generate`,
+          tooltip: `Run "prisma generate"`,
           // ? (@druue) The arguments property does not seem to actually
           // ? return an array of arguments. It would consistently
           // ? return one singular string element, even when defined as:

--- a/packages/vscode/src/CodeLensProvider.ts
+++ b/packages/vscode/src/CodeLensProvider.ts
@@ -1,0 +1,98 @@
+import * as vscode from 'vscode'
+import * as cp from 'child_process'
+
+/**
+ * CodelensProvider
+ */
+export class CodelensProvider implements vscode.CodeLensProvider {
+  private enabled: boolean
+  private scriptRunner: string
+  private generatorRegex: RegExp
+  private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>()
+  public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event
+
+  constructor() {
+    this.generatorRegex = /(generator [a-zA-Z]+ {)/g
+    this.enabled = vscode.workspace.getConfiguration('prisma').get('enableCodeLens', true)
+    this.scriptRunner = vscode.workspace.getConfiguration('prisma').get('scriptRunner')!
+
+    vscode.workspace.onDidChangeConfiguration((_) => {
+      this._onDidChangeCodeLenses.fire()
+    })
+  }
+
+  public updateScriptRunner(scriptRunner: string) {
+    this.scriptRunner = scriptRunner
+  }
+
+  public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {
+    if (!this.enabled) {
+      return []
+    }
+
+    const codelenses = [this.getCodeLensGenerateSchema(document, token)]
+    return ([] as vscode.CodeLens[]).concat(...codelenses)
+  }
+
+  private getCodeLensGenerateSchema(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {
+    const generatorRange = this.getGeneratorRange(document, token)
+
+    return generatorRange
+      ? [
+          new vscode.CodeLens(generatorRange, {
+            title: 'Generate Prisma Client',
+            command: 'prisma.generateClient',
+            tooltip: 'Codelens to generate your Prisma client',
+            arguments: [this.scriptRunner],
+          }),
+        ]
+      : []
+  }
+
+  // ? (@druue) I really don't like finding it like this :|
+  private getGeneratorRange(document: vscode.TextDocument, _token: vscode.CancellationToken): vscode.Range | undefined {
+    const regex = new RegExp(this.generatorRegex)
+    const text = document.getText()
+
+    let matches
+    while ((matches = regex.exec(text)) !== null) {
+      const line = document.lineAt(document.positionAt(matches.index).line)
+      const indexOf = line.text.indexOf(matches[0])
+      const position = new vscode.Position(line.lineNumber, indexOf)
+      const range = document.getWordRangeAtPosition(position, new RegExp(this.generatorRegex))
+      if (range) {
+        return range
+      }
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function generateClient(args: any) {
+  const prismaGenerateOutputChannel = vscode.window.createOutputChannel('Prisma Generate')
+  const rootPath = vscode.workspace.workspaceFolders?.[0].uri.path
+  const cmd = `(cd ${rootPath} && ${args} prisma generate)`
+
+  prismaGenerateOutputChannel.clear()
+  prismaGenerateOutputChannel.show(true)
+  prismaGenerateOutputChannel.appendLine(['Running prisma generate:', rootPath, cmd].join('\n- '))
+
+  const handleExec = (err: cp.ExecException | null, stdout: string, stderr: string) => {
+    try {
+      if (err) {
+        prismaGenerateOutputChannel.appendLine(err.message)
+        return
+      }
+      if (stdout) {
+        prismaGenerateOutputChannel.append(stdout)
+      }
+      if (stderr) {
+        prismaGenerateOutputChannel.append(stderr)
+      }
+    } catch (e) {
+      prismaGenerateOutputChannel.append(e as string)
+    }
+  }
+
+  cp.exec(cmd, (err, stdout, stderr) => handleExec(err, stdout, stderr))
+}

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -216,13 +216,9 @@ const plugin: PrismaVSCodePlugin = {
         if (event.affectsConfiguration('prisma.fileWatcher')) {
           setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
         }
-
-        if (event.affectsConfiguration('prisma.scriptRunner')) {
-          codelensProvider.updateScriptRunner(workspace.getConfiguration('prisma').get('scriptRunner')!)
-        }
       }),
 
-      commands.registerCommand('prisma.generateClient', (args) => generateClient(args)),
+      commands.registerCommand('prisma.generate', (args: string) => generateClient(args)),
 
       commands.registerCommand('prisma.restartLanguageServer', async () => {
         client = await restartClient(context, client, serverOptions, clientOptions)

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -13,6 +13,7 @@ import {
   TextDocument,
   window,
   workspace,
+  languages,
 } from 'vscode'
 import {
   CodeAction as lsCodeAction,
@@ -35,6 +36,7 @@ import {
 import { PrismaVSCodePlugin } from '../types'
 import paths from 'env-paths'
 import FileWatcher from 'watcher'
+import { CodelensProvider, generateClient } from '../../CodeLensProvider'
 
 const packageJson = require('../../../../package.json') // eslint-disable-line
 
@@ -116,6 +118,9 @@ const plugin: PrismaVSCodePlugin = {
   enabled: () => true,
   activate: async (context) => {
     const isDebugOrTest = isDebugOrTestSession()
+    const codelensProvider = new CodelensProvider()
+
+    languages.registerCodeLensProvider('*', codelensProvider)
 
     setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
 
@@ -211,11 +216,25 @@ const plugin: PrismaVSCodePlugin = {
         if (event.affectsConfiguration('prisma.fileWatcher')) {
           setGenerateWatcher(!!workspace.getConfiguration('prisma').get('fileWatcher'))
         }
+
+        if (event.affectsConfiguration('prisma.scriptRunner')) {
+          codelensProvider.updateScriptRunner(workspace.getConfiguration('prisma').get('scriptRunner')!)
+        }
       }),
+
+      commands.registerCommand('prisma.generateClient', (args) => generateClient(args)),
 
       commands.registerCommand('prisma.restartLanguageServer', async () => {
         client = await restartClient(context, client, serverOptions, clientOptions)
         window.showInformationMessage('Prisma language server restarted.') // eslint-disable-line @typescript-eslint/no-floating-promises
+      }),
+
+      commands.registerCommand('prisma.enableCodeLens', async () => {
+        await workspace.getConfiguration('prisma').update('enableCodeLens', true, true)
+      }),
+
+      commands.registerCommand('prisma.disableCodeLens', async () => {
+        await workspace.getConfiguration('prisma').update('enableCodeLens', false, true)
       }),
 
       /* This command is part of the workaround for https://github.com/prisma/language-tools/issues/311 */


### PR DESCRIPTION
Added a codelens provider to our vscode extension with one codelens command to generate your Prisma client

This uses new config to define which script runner to use and whether you want the codelens active or not
```
prisma.enableCodeLens: [true, false] // default: true
prisma.scriptRunner: ["npx", "pnpm", "yarn"] // default: npx
```

This shows the following clickable text above the generator block
<img width="728" alt="image" src="https://github.com/prisma/language-tools/assets/29753584/505d6945-eadf-402c-be4c-950ae2c4a5c9">

Which opens up a new output window wherein we run `prisma generate` using the defined script runner

https://github.com/prisma/language-tools/assets/29753584/118f61dc-dc09-4fe8-b1ec-0ff610efe6e4


closes https://github.com/prisma/language-tools/issues/1651