### PR TITLE
Preparatory refactor for split schema support

### DIFF
--- a/packages/language-server/src/lib/MessageHandler.ts
+++ b/packages/language-server/src/lib/MessageHandler.ts
@@ -259,7 +259,7 @@ export function handleRenameRequest(params: RenameParams, document: TextDocument
     if (isDatamodelBlockRename) {
       // get definition of model or enum
       const matchBlockBeginning = new RegExp(`\\s*(${block.type})\\s+(${currentName})\\s*({)`, 'g')
-      const lineOfDefinition = schemaLines.find((l) => matchBlockBeginning.test(l.text))
+      const lineOfDefinition = schemaLines.find((line) => matchBlockBeginning.test(line.text))
       if (!lineOfDefinition) {
         return
       }

--- a/packages/language-server/src/lib/MessageHandler.ts
+++ b/packages/language-server/src/lib/MessageHandler.ts
@@ -23,8 +23,6 @@ import type { TextDocument } from 'vscode-languageserver-textdocument'
 import format from './prisma-schema-wasm/format'
 import lint from './prisma-schema-wasm/lint'
 
-import { getCurrentLine } from './ast'
-
 import { quickFix } from './code-actions'
 import {
   insertBasicRename,

--- a/packages/language-server/src/lib/MessageHandler.ts
+++ b/packages/language-server/src/lib/MessageHandler.ts
@@ -53,7 +53,7 @@ import {
   getDatamodelBlock,
 } from './ast'
 import { prismaSchemaWasmCompletions, localCompletions } from './completions'
-import { PrismaSchema } from './Schema'
+import { PrismaSchema, SchemaDocument } from './Schema'
 
 export function handleDiagnosticsRequest(
   document: TextDocument,
@@ -126,24 +126,24 @@ export function handleDefinitionRequest(document: TextDocument, params: Declarat
   // get start position of block
   const results = schema
     .linesAsArray()
-    .map(([fileUri, lineNo, line]) => {
+    .map(([document, lineNo, line]) => {
       if (
         (line.includes('model') && line.includes(word)) ||
         (line.includes('type') && line.includes(word)) ||
         (line.includes('enum') && line.includes(word))
       ) {
-        return [fileUri, lineNo]
+        return [document, lineNo]
       }
     })
-    .filter((result) => result !== undefined) as [string, number][]
+    .filter((result) => result !== undefined) as [SchemaDocument, number][]
 
   if (results.length === 0) {
     return
   }
 
   const foundBlocks: Block[] = results
-    .map(([fileUri, lineNo]) => {
-      const block = getBlockAtPosition(fileUri, lineNo, schema)
+    .map(([document, lineNo]) => {
+      const block = getBlockAtPosition(document.fileUri, lineNo, schema)
       if (block && block.name === word && block.range.start.line === lineNo) {
         return block
       }

--- a/packages/language-server/src/lib/MessageHandler.ts
+++ b/packages/language-server/src/lib/MessageHandler.ts
@@ -228,11 +228,12 @@ export function handleRenameRequest(params: RenameParams, document: TextDocument
   const schema = PrismaSchema.singleFile(document)
   const schemaLines = schema.linesAsArray()
   const position = params.position
-  const currentLine: string = getCurrentLine(document, position.line)
   const block = getBlockAtPosition(document.uri, position.line, schema)
   if (!block) {
-    return
+    return undefined
   }
+
+  const currentLine = block.definingDocument.getLineContent(params.position.line)
 
   const isDatamodelBlockRename = isDatamodelBlockName(position, block, schema, document)
 

--- a/packages/language-server/src/lib/Schema.ts
+++ b/packages/language-server/src/lib/Schema.ts
@@ -1,0 +1,69 @@
+import { TextDocument } from 'vscode-languageserver-textdocument'
+
+export type Line = [document: SchemaDocument, lineNo: number, text: string]
+export class SchemaDocument {
+  #untrimmedLines: string[]
+
+  static fromTextDocument(textDocument: TextDocument): SchemaDocument {
+    return new SchemaDocument(textDocument.uri, textDocument.getText())
+  }
+
+  constructor(
+    readonly fileUri: string,
+    readonly content: string,
+  ) {
+    this.#untrimmedLines = content.split(/\r?\n/)
+  }
+
+  get lines(): Line[] {
+    return this.#untrimmedLines.map((line, lineIndex) => [this, lineIndex, line])
+  }
+
+  getLineContent(lineIndex: number): string {
+    return this.#untrimmedLines[lineIndex][2]
+  }
+
+  getUntrimmedLine(lineIndex: number): string {
+    return this.#untrimmedLines[lineIndex]
+  }
+}
+
+type FindRegexpResult = {
+  match: RegExpExecArray
+  documentUri: string
+}
+
+export class PrismaSchema {
+  static singleFile(textDocument: TextDocument) {
+    return new PrismaSchema([SchemaDocument.fromTextDocument(textDocument)])
+  }
+
+  constructor(private readonly documents: SchemaDocument[]) {}
+
+  *iterLines(): Generator<Line, void, void> {
+    for (const doc of this.documents) {
+      for (const line of doc.lines) {
+        yield line
+      }
+    }
+  }
+
+  linesAsArray(): Line[] {
+    return Array.from(this.iterLines())
+  }
+
+  findDocByUri(fileUri: string): SchemaDocument | undefined {
+    return this.documents.find((doc) => doc.fileUri === fileUri)
+  }
+
+  findWithRegex(regexp: RegExp): FindRegexpResult | undefined {
+    for (const doc of this.documents) {
+      regexp.lastIndex = 0
+      const match = regexp.exec(doc.content)
+      if (match) {
+        return { match, documentUri: doc.fileUri }
+      }
+    }
+    return undefined
+  }
+}

--- a/packages/language-server/src/lib/Schema.ts
+++ b/packages/language-server/src/lib/Schema.ts
@@ -16,11 +16,11 @@ export class SchemaDocument {
   }
 
   get lines(): Line[] {
-    return this.#untrimmedLines.map((line, lineIndex) => [this, lineIndex, line])
+    return this.#untrimmedLines.map((line, lineIndex) => [this, lineIndex, line.trim()] as const)
   }
 
   getLineContent(lineIndex: number): string {
-    return this.#untrimmedLines[lineIndex][2]
+    return this.#untrimmedLines[lineIndex].trim()
   }
 
   getUntrimmedLine(lineIndex: number): string {

--- a/packages/language-server/src/lib/ast/block.ts
+++ b/packages/language-server/src/lib/ast/block.ts
@@ -70,23 +70,23 @@ export function getDatamodelBlock(blockName: string, schema: PrismaSchema): Bloc
   // get start position of block
   const results = schema
     .linesAsArray()
-    .map(([fileUri, index, line]) => {
+    .map(([document, index, line]) => {
       if (
         (line.includes('model') || line.includes('type') || line.includes('enum') || line.includes('view')) &&
         line.includes(blockName)
       ) {
-        return [fileUri, index]
+        return [document, index]
       }
     })
-    .filter((result) => result !== undefined) as [string, number][]
+    .filter((result) => result !== undefined) as [SchemaDocument, number][]
 
   if (results.length === 0) {
     return
   }
 
   const foundBlocks: Block[] = results
-    .map(([fileUri, lineNo]) => {
-      const block = getBlockAtPosition(fileUri, lineNo, schema)
+    .map(([document, lineNo]) => {
+      const block = getBlockAtPosition(document.fileUri, lineNo, schema)
       if (block && block.name === blockName) {
         return block
       }

--- a/packages/language-server/src/lib/ast/block.ts
+++ b/packages/language-server/src/lib/ast/block.ts
@@ -6,41 +6,37 @@ import { MAX_SAFE_VALUE_i32 } from '../constants'
 
 import { getFieldType } from './fields'
 import { getBlockAtPosition } from './findAtPosition'
+import { PrismaSchema, SchemaDocument } from '../Schema'
 
-export class Block {
+export interface Block {
   type: BlockType
   range: Range
   nameRange: Range
   name: string
-
-  constructor(type: BlockType, range: Range, nameRange: Range, name: string) {
-    this.type = type
-    this.range = range
-    this.nameRange = nameRange
-    this.name = name
-  }
+  definingDocument: SchemaDocument
 }
 
 // Note: this is a generator function, which returns a Generator object.
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
-export function* getBlocks(lines: string[]): Generator<Block, void, void> {
+export function* getBlocks(schema: PrismaSchema): Generator<Block, void, void> {
   let blockName = ''
   let blockType = ''
   let blockNameRange: Range | undefined
   let blockStart: Position = Position.create(0, 0)
   const allowedBlockIdentifiers: BlockType[] = ['model', 'type', 'enum', 'datasource', 'generator', 'view']
 
-  for (const [key, item] of lines.entries()) {
+  for (const [document, lineNo, item] of schema.iterLines()) {
     // if start of block: `BlockType name {`
     if (allowedBlockIdentifiers.some((identifier) => item.startsWith(identifier)) && item.includes('{')) {
       if (blockType && blockNameRange) {
         // Recover from missing block end
-        yield new Block(
-          blockType as BlockType,
-          Range.create(blockStart, Position.create(key - 1, 0)),
-          blockNameRange,
-          blockName,
-        )
+        yield {
+          type: blockType as BlockType,
+          range: Range.create(blockStart, Position.create(lineNo - 1, 0)),
+          nameRange: blockNameRange,
+          name: blockName,
+          definingDocument: document,
+        }
         blockType = ''
         blockNameRange = undefined
       }
@@ -50,45 +46,47 @@ export function* getBlocks(lines: string[]): Generator<Block, void, void> {
       blockName = item.slice(blockType.length, item.length - 2).trimStart()
       const startCharacter = item.length - 2 - blockName.length
       blockName = blockName.trimEnd()
-      blockNameRange = Range.create(key, startCharacter, key, startCharacter + blockName.length)
-      blockStart = Position.create(key, 0)
+      blockNameRange = Range.create(lineNo, startCharacter, lineNo, startCharacter + blockName.length)
+      blockStart = Position.create(lineNo, 0)
       continue
     }
 
     // if end of block: `}`
     if (item.startsWith('}') && blockType && blockNameRange) {
-      yield new Block(
-        blockType as BlockType,
-        Range.create(blockStart, Position.create(key, 1)),
-        blockNameRange,
-        blockName,
-      )
+      yield {
+        type: blockType as BlockType,
+        range: Range.create(blockStart, Position.create(lineNo, 1)),
+        nameRange: blockNameRange,
+        name: blockName,
+        definingDocument: document,
+      }
       blockType = ''
       blockNameRange = undefined
     }
   }
 }
 
-export function getDatamodelBlock(blockName: string, lines: string[]): Block | void {
+export function getDatamodelBlock(blockName: string, schema: PrismaSchema): Block | void {
   // get start position of block
-  const results: number[] = lines
-    .map((line, index) => {
+  const results = schema
+    .linesAsArray()
+    .map(([fileUri, index, line]) => {
       if (
         (line.includes('model') || line.includes('type') || line.includes('enum') || line.includes('view')) &&
         line.includes(blockName)
       ) {
-        return index
+        return [fileUri, index]
       }
     })
-    .filter((index) => index !== undefined) as number[]
+    .filter((result) => result !== undefined) as [string, number][]
 
   if (results.length === 0) {
     return
   }
 
   const foundBlocks: Block[] = results
-    .map((result) => {
-      const block = getBlockAtPosition(result, lines)
+    .map(([fileUri, lineNo]) => {
+      const block = getBlockAtPosition(fileUri, lineNo, schema)
       if (block && block.name === blockName) {
         return block
       }
@@ -106,12 +104,13 @@ export function getDatamodelBlock(blockName: string, lines: string[]): Block | v
   return foundBlocks[0]
 }
 
-export function getFieldsFromCurrentBlock(lines: string[], block: Block, position?: Position): string[] {
+export function getFieldsFromCurrentBlock(schema: PrismaSchema, block: Block, position?: Position): string[] {
   const fieldNames: string[] = []
+  const lines = block.definingDocument.lines
 
   for (let lineIndex = block.range.start.line + 1; lineIndex < block.range.end.line; lineIndex++) {
     if (!position || lineIndex !== position.line) {
-      const line = lines[lineIndex]
+      const [, , line] = lines[lineIndex]
       const fieldName = getFieldNameFromLine(line)
       if (fieldName) {
         fieldNames.push(fieldName)
@@ -122,12 +121,22 @@ export function getFieldsFromCurrentBlock(lines: string[], block: Block, positio
   return fieldNames
 }
 
-export function getFieldTypesFromCurrentBlock(lines: string[], block: Block, position?: Position) {
-  const fieldTypes = new Map<string, { lineIndexes: number[]; fieldName: string | undefined }>()
+export type FoundLocation = {
+  document: SchemaDocument
+  lineIndex: number
+}
+
+export type RenameFieldLocation = {
+  fieldName: string
+  locations: FoundLocation[]
+}
+
+export function getFieldTypesFromCurrentBlock(schema: PrismaSchema, block: Block, position?: Position) {
+  const fieldTypes = new Map<string, RenameFieldLocation>()
   const fieldTypeNames: Record<string, string> = {}
 
   let reachedStartLine = false
-  for (const [lineIndex, line] of lines.entries()) {
+  for (const [document, lineIndex, line] of schema.iterLines()) {
     if (lineIndex === block.range.start.line + 1) {
       reachedStartLine = true
     }
@@ -145,10 +154,10 @@ export function getFieldTypesFromCurrentBlock(lines: string[], block: Block, pos
         if (!existingFieldType) {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           const fieldName = getFieldNameFromLine(line)!
-          fieldTypes.set(fieldType, { lineIndexes: [lineIndex], fieldName })
+          fieldTypes.set(fieldType, { locations: [{ document, lineIndex }], fieldName })
           fieldTypeNames[fieldName] = fieldType
         } else {
-          existingFieldType.lineIndexes.push(lineIndex)
+          existingFieldType.locations.push({ document, lineIndex })
           fieldTypes.set(fieldType, existingFieldType)
         }
       }
@@ -158,16 +167,10 @@ export function getFieldTypesFromCurrentBlock(lines: string[], block: Block, pos
 }
 
 export function getCompositeTypeFieldsRecursively(
-  lines: string[],
+  schema: PrismaSchema,
   compositeTypeFieldNames: string[],
   fieldTypesFromBlock: {
-    fieldTypes: Map<
-      string,
-      {
-        lineIndexes: number[]
-        fieldName: string | undefined
-      }
-    >
+    fieldTypes: Map<string, RenameFieldLocation>
     fieldTypeNames: Record<string, string>
   },
 ): string[] {
@@ -184,7 +187,7 @@ export function getCompositeTypeFieldsRecursively(
     return []
   }
 
-  const typeBlock = getDatamodelBlock(fieldTypeName, lines)
+  const typeBlock = getDatamodelBlock(fieldTypeName, schema)
   if (!typeBlock || typeBlock.type !== 'type') {
     return []
   }
@@ -192,12 +195,12 @@ export function getCompositeTypeFieldsRecursively(
   // if we are not at the end of the composite type, continue recursively
   if (compositeTypeFieldNames.length) {
     return getCompositeTypeFieldsRecursively(
-      lines,
+      schema,
       compositeTypeFieldNames,
-      getFieldTypesFromCurrentBlock(lines, typeBlock),
+      getFieldTypesFromCurrentBlock(schema, typeBlock),
     )
   } else {
-    return getFieldsFromCurrentBlock(lines, typeBlock)
+    return getFieldsFromCurrentBlock(schema, typeBlock)
   }
 }
 

--- a/packages/language-server/src/lib/ast/configBlock.ts
+++ b/packages/language-server/src/lib/ast/configBlock.ts
@@ -8,7 +8,7 @@ import { PrismaSchema } from '../Schema'
 export function getFirstDatasourceName(schema: PrismaSchema): string | undefined {
   const datasourceBlockFirstLine = schema
     .linesAsArray()
-    .find((l) => l.text.startsWith('datasource') && l.text.includes('{'))
+    .find((line) => line.text.startsWith('datasource') && line.text.includes('{'))
   if (!datasourceBlockFirstLine) {
     return undefined
   }

--- a/packages/language-server/src/lib/ast/configBlock.ts
+++ b/packages/language-server/src/lib/ast/configBlock.ts
@@ -8,12 +8,12 @@ import { PrismaSchema } from '../Schema'
 export function getFirstDatasourceName(schema: PrismaSchema): string | undefined {
   const datasourceBlockFirstLine = schema
     .linesAsArray()
-    .find(([, , l]) => l.startsWith('datasource') && l.includes('{'))
+    .find((l) => l.text.startsWith('datasource') && l.text.includes('{'))
   if (!datasourceBlockFirstLine) {
     return undefined
   }
-  const indexOfBracket = datasourceBlockFirstLine.indexOf('{')
-  return datasourceBlockFirstLine[2].slice('datasource'.length, indexOfBracket).trim()
+  const indexOfBracket = datasourceBlockFirstLine.text.indexOf('{')
+  return datasourceBlockFirstLine.text.slice('datasource'.length, indexOfBracket).trim()
 }
 
 export function getFirstDatasourceProvider(schema: PrismaSchema): string | undefined {

--- a/packages/language-server/src/lib/ast/findAtPosition.ts
+++ b/packages/language-server/src/lib/ast/findAtPosition.ts
@@ -53,7 +53,7 @@ export function getWordAtPosition(document: TextDocument, position: Position): s
 
 export function getBlockAtPosition(fileUri: string, line: number, schema: PrismaSchema): Block | undefined {
   for (const block of getBlocks(schema)) {
-    if (fileUri !== block.definingDocument.fileUri) {
+    if (fileUri !== block.definingDocument.uri) {
       continue
     }
     if (block.range.start.line > line) {

--- a/packages/language-server/src/lib/ast/findAtPosition.ts
+++ b/packages/language-server/src/lib/ast/findAtPosition.ts
@@ -4,6 +4,7 @@ import type { TextDocument } from 'vscode-languageserver-textdocument'
 import { MAX_SAFE_VALUE_i32 } from '../constants'
 
 import { Block, getBlocks } from './block'
+import { PrismaSchema } from '../Schema'
 
 export function fullDocumentRange(document: TextDocument): Range {
   const lastLineId = document.lineCount - 1
@@ -50,8 +51,11 @@ export function getWordAtPosition(document: TextDocument, position: Position): s
   return currentLine.slice(beginning, end + position.character)
 }
 
-export function getBlockAtPosition(line: number, lines: string[]): Block | void {
-  for (const block of getBlocks(lines)) {
+export function getBlockAtPosition(fileUri: string, line: number, schema: PrismaSchema): Block | void {
+  for (const block of getBlocks(schema)) {
+    if (fileUri !== block.definingDocument.fileUri) {
+      continue
+    }
     if (block.range.start.line > line) {
       return
     }

--- a/packages/language-server/src/lib/ast/findAtPosition.ts
+++ b/packages/language-server/src/lib/ast/findAtPosition.ts
@@ -51,7 +51,7 @@ export function getWordAtPosition(document: TextDocument, position: Position): s
   return currentLine.slice(beginning, end + position.character)
 }
 
-export function getBlockAtPosition(fileUri: string, line: number, schema: PrismaSchema): Block | void {
+export function getBlockAtPosition(fileUri: string, line: number, schema: PrismaSchema): Block | undefined {
   for (const block of getBlocks(schema)) {
     if (fileUri !== block.definingDocument.fileUri) {
       continue

--- a/packages/language-server/src/lib/ast/relations.ts
+++ b/packages/language-server/src/lib/ast/relations.ts
@@ -2,8 +2,8 @@ import { PrismaSchema } from '../Schema'
 
 export function getAllRelationNames(schema: PrismaSchema, regexFilter: RegExp): string[] {
   const modelNames: string[] = []
-  for (const [, , line] of schema.iterLines()) {
-    const result = regexFilter.exec(line)
+  for (const { text } of schema.iterLines()) {
+    const result = regexFilter.exec(text)
     if (result && result[2]) {
       modelNames.push(result[2])
     }

--- a/packages/language-server/src/lib/ast/relations.ts
+++ b/packages/language-server/src/lib/ast/relations.ts
@@ -1,6 +1,8 @@
-export function getAllRelationNames(lines: string[], regexFilter: RegExp): string[] {
+import { PrismaSchema } from '../Schema'
+
+export function getAllRelationNames(schema: PrismaSchema, regexFilter: RegExp): string[] {
   const modelNames: string[] = []
-  for (const line of lines) {
+  for (const [, , line] of schema.iterLines()) {
     const result = regexFilter.exec(line)
     if (result && result[2]) {
       modelNames.push(result[2])

--- a/packages/language-server/src/lib/code-actions/index.ts
+++ b/packages/language-server/src/lib/code-actions/index.ts
@@ -11,7 +11,8 @@ import levenshtein from 'js-levenshtein'
 
 import codeActions from '../prisma-schema-wasm/codeActions'
 import { relationNamesRegexFilter } from '../constants'
-import { convertDocumentTextToTrimmedLineArray, getAllRelationNames } from '../ast'
+import { getAllRelationNames } from '../ast'
+import { PrismaSchema } from '../Schema'
 
 function getInsertRange(document: TextDocument): Range {
   // to insert text into a document create a range where start === end.
@@ -88,6 +89,7 @@ export function quickFix(
   params: CodeActionParams,
   onError?: (errorMessage: string) => void,
 ): CodeAction[] {
+  const schema = PrismaSchema.singleFile(textDocument)
   const diagnostics: Diagnostic[] = params.context.diagnostics
 
   if (!diagnostics || diagnostics.length === 0) {
@@ -114,8 +116,7 @@ export function quickFix(
       const hasTypeModifierArray: boolean = diagText.endsWith('[]')
       const hasTypeModifierOptional: boolean = diagText.endsWith('?')
       diagText = removeTypeModifiers(hasTypeModifierArray, hasTypeModifierOptional, diagText)
-      const lines: string[] = convertDocumentTextToTrimmedLineArray(textDocument)
-      const spellingSuggestion = getSpellingSuggestions(diagText, getAllRelationNames(lines, relationNamesRegexFilter))
+      const spellingSuggestion = getSpellingSuggestions(diagText, getAllRelationNames(schema, relationNamesRegexFilter))
       if (spellingSuggestion) {
         codeActionList.push({
           title: `Change spelling to '${spellingSuggestion}'`,

--- a/packages/language-server/src/lib/code-actions/rename.ts
+++ b/packages/language-server/src/lib/code-actions/rename.ts
@@ -319,6 +319,7 @@ export function renameReferencesForEnumValue(
   for (const [document, lineIndex, value] of schema.iterLines()) {
     if (value.includes(searchString) && value.includes(enumName)) {
       const currentLineUntrimmed = document.getUntrimmedLine(lineIndex)
+      console.log({ currentLineUntrimmed })
       // get the index of the second word
       const indexOfCurrentName = currentLineUntrimmed.indexOf(searchString)
       appendEdit(edits, document.fileUri, {
@@ -332,7 +333,7 @@ export function renameReferencesForEnumValue(
             character: indexOfCurrentName + searchString.length,
           },
         },
-        newText: newName,
+        newText: `@default(${newName})`,
       })
     }
   }

--- a/packages/language-server/src/lib/code-actions/rename.ts
+++ b/packages/language-server/src/lib/code-actions/rename.ts
@@ -319,7 +319,6 @@ export function renameReferencesForEnumValue(
   for (const [document, lineIndex, value] of schema.iterLines()) {
     if (value.includes(searchString) && value.includes(enumName)) {
       const currentLineUntrimmed = document.getUntrimmedLine(lineIndex)
-      console.log({ currentLineUntrimmed })
       // get the index of the second word
       const indexOfCurrentName = currentLineUntrimmed.indexOf(searchString)
       appendEdit(edits, document.fileUri, {

--- a/packages/language-server/src/lib/completions/attributes.ts
+++ b/packages/language-server/src/lib/completions/attributes.ts
@@ -73,23 +73,23 @@ function filterSuggestionsForBlock(
 ): CompletionItem[] {
   let reachedStartLine = false
 
-  for (const [, lineNo, line] of schema.iterLines()) {
-    if (lineNo === block.range.start.line + 1) {
+  for (const { lineIndex, text } of schema.iterLines()) {
+    if (lineIndex === block.range.start.line + 1) {
       reachedStartLine = true
     }
     if (!reachedStartLine) {
       continue
     }
-    if (lineNo === block.range.end.line) {
+    if (lineIndex === block.range.end.line) {
       break
     }
 
     // Ignore commented lines
-    if (!line.startsWith('//')) {
+    if (!text.startsWith('//')) {
       // TODO we should also remove the other suggestions if used (default()...)
       // * Filter already-present attributes that can't be duplicated
       ;['@id', '@@map', '@@ignore', '@@schema'].forEach((label) => {
-        if (line.includes(label)) {
+        if (text.includes(label)) {
           suggestions = suggestions.filter((suggestion) => suggestion.label !== label)
 
           if (label === '@@ignore') {

--- a/packages/language-server/src/lib/completions/attributes.ts
+++ b/packages/language-server/src/lib/completions/attributes.ts
@@ -16,6 +16,7 @@ import {
 
 import { getNativeTypes } from './types'
 import { BlockType } from '../types'
+import { PrismaSchema } from '../Schema'
 
 const fieldAttributes: CompletionItem[] = convertAttributesToCompletionItems(
   completions.fieldAttributes,
@@ -27,15 +28,11 @@ const blockAttributes: CompletionItem[] = convertAttributesToCompletionItems(
   CompletionItemKind.Property,
 )
 
-const filterContextBlockAttributes = (
-  block: Block,
-  lines: string[],
-  suggestions: CompletionItem[],
-): CompletionItem[] => {
+const filterContextBlockAttributes = (schema: PrismaSchema, suggestions: CompletionItem[]): CompletionItem[] => {
   // We can filter on the datasource
-  const datasourceProvider = getFirstDatasourceProvider(lines)
+  const datasourceProvider = getFirstDatasourceProvider(schema)
   // We can filter on the previewFeatures enabled
-  const previewFeatures = getAllPreviewFeaturesFromGenerators(lines)
+  const previewFeatures = getAllPreviewFeaturesFromGenerators(schema)
 
   // Full text indexes (MySQL and MongoDB)
   // https://www.prisma.io/docs/concepts/components/prisma-schema/indexes#full-text-indexes-mysql-and-mongodb
@@ -69,26 +66,30 @@ const filterContextBlockAttributes = (
  * Removes all block attribute suggestions that are invalid in this context.
  * E.g. `@@id()` when already used should not be in the suggestions.
  */
-function filterSuggestionsForBlock(suggestions: CompletionItem[], block: Block, lines: string[]): CompletionItem[] {
+function filterSuggestionsForBlock(
+  suggestions: CompletionItem[],
+  block: Block,
+  schema: PrismaSchema,
+): CompletionItem[] {
   let reachedStartLine = false
 
-  for (const [key, item] of lines.entries()) {
-    if (key === block.range.start.line + 1) {
+  for (const [, lineNo, line] of schema.iterLines()) {
+    if (lineNo === block.range.start.line + 1) {
       reachedStartLine = true
     }
     if (!reachedStartLine) {
       continue
     }
-    if (key === block.range.end.line) {
+    if (lineNo === block.range.end.line) {
       break
     }
 
     // Ignore commented lines
-    if (!item.startsWith('//')) {
+    if (!line.startsWith('//')) {
       // TODO we should also remove the other suggestions if used (default()...)
       // * Filter already-present attributes that can't be duplicated
       ;['@id', '@@map', '@@ignore', '@@schema'].forEach((label) => {
-        if (item.includes(label)) {
+        if (line.includes(label)) {
           suggestions = suggestions.filter((suggestion) => suggestion.label !== label)
 
           if (label === '@@ignore') {
@@ -162,14 +163,14 @@ function filterSuggestionsForLine(
 /**
  * * Only models and views currently support block attributes
  */
-export function getSuggestionForBlockAttribute(block: Block, lines: string[]): CompletionItem[] {
+export function getSuggestionForBlockAttribute(block: Block, schema: PrismaSchema): CompletionItem[] {
   if (!(['model', 'view'] as BlockType[]).includes(block.type)) {
     return []
   }
 
-  const suggestions: CompletionItem[] = filterSuggestionsForBlock(klona(blockAttributes), block, lines)
+  const suggestions: CompletionItem[] = filterSuggestionsForBlock(klona(blockAttributes), block, schema)
 
-  return filterContextBlockAttributes(block, lines, suggestions)
+  return filterContextBlockAttributes(schema, suggestions)
 }
 
 /**
@@ -187,7 +188,7 @@ export function getSuggestionForBlockAttribute(block: Block, lines: string[]): C
 export function getSuggestionForFieldAttribute(
   block: Block,
   currentLine: string,
-  lines: string[],
+  schema: PrismaSchema,
   wordsBeforePosition: string[],
   document: TextDocument,
   onError?: (errorMessage: string) => void,
@@ -202,7 +203,7 @@ export function getSuggestionForFieldAttribute(
 
   // Because @.?
   if (wordsBeforePosition.length >= 2) {
-    const datasourceName = getFirstDatasourceName(lines)
+    const datasourceName = getFirstDatasourceName(schema)
     const prismaType = wordsBeforePosition[1]
     const nativeTypeSuggestions = getNativeTypes(document, prismaType, onError)
 
@@ -228,11 +229,11 @@ export function getSuggestionForFieldAttribute(
 
   suggestions.push(...fieldAttributes)
 
-  const datamodelBlock = getDatamodelBlock(fieldType, lines)
+  const datamodelBlock = getDatamodelBlock(fieldType, schema)
 
   suggestions = filterSuggestionsForLine(suggestions, currentLine, fieldType, datamodelBlock?.type)
 
-  suggestions = filterSuggestionsForBlock(suggestions, block, lines)
+  suggestions = filterSuggestionsForBlock(suggestions, block, schema)
 
   return {
     items: suggestions,

--- a/packages/language-server/src/lib/completions/attributes.ts
+++ b/packages/language-server/src/lib/completions/attributes.ts
@@ -85,23 +85,25 @@ function filterSuggestionsForBlock(
     }
 
     // Ignore commented lines
-    if (!text.startsWith('//')) {
-      // TODO we should also remove the other suggestions if used (default()...)
-      // * Filter already-present attributes that can't be duplicated
-      ;['@id', '@@map', '@@ignore', '@@schema'].forEach((label) => {
-        if (text.includes(label)) {
-          suggestions = suggestions.filter((suggestion) => suggestion.label !== label)
-
-          if (label === '@@ignore') {
-            suggestions = suggestions.filter((suggestion) => suggestion.label !== '@ignore')
-          }
-
-          if (label === '@id') {
-            suggestions = suggestions.filter((suggestion) => suggestion.label !== '@@id')
-          }
-        }
-      })
+    if (text.startsWith('//')) {
+      continue
     }
+
+    // TODO we should also remove the other suggestions if used (default()...)
+    // * Filter already-present attributes that can't be duplicated
+    ;['@id', '@@map', '@@ignore', '@@schema'].forEach((label) => {
+      if (text.includes(label)) {
+        suggestions = suggestions.filter((suggestion) => suggestion.label !== label)
+
+        if (label === '@@ignore') {
+          suggestions = suggestions.filter((suggestion) => suggestion.label !== '@ignore')
+        }
+
+        if (label === '@id') {
+          suggestions = suggestions.filter((suggestion) => suggestion.label !== '@@id')
+        }
+      }
+    })
   }
 
   return suggestions

--- a/packages/language-server/src/lib/completions/blocks.ts
+++ b/packages/language-server/src/lib/completions/blocks.ts
@@ -5,6 +5,7 @@ import { convertToCompletionItems } from './internals'
 
 import * as completions from './completions.json'
 import { getAllPreviewFeaturesFromGenerators, getFirstDatasourceProvider } from '../ast'
+import { PrismaSchema } from '../Schema'
 
 /**
  * ```
@@ -21,12 +22,12 @@ const allowedBlockTypes: CompletionItem[] = convertToCompletionItems(completions
  * @param lines
  * @returns the list of block suggestions
  */
-export function getSuggestionForBlockTypes(lines: string[]): CompletionList {
+export function getSuggestionForBlockTypes(schema: PrismaSchema): CompletionList {
   // create deep copy
   let suggestions: CompletionItem[] = klona(allowedBlockTypes)
 
-  const datasourceProvider = getFirstDatasourceProvider(lines)
-  const previewFeatures = getAllPreviewFeaturesFromGenerators(lines)
+  const datasourceProvider = getFirstDatasourceProvider(schema)
+  const previewFeatures = getAllPreviewFeaturesFromGenerators(schema)
 
   const isEnumAvailable = Boolean(!datasourceProvider?.includes('sqlite'))
 

--- a/packages/language-server/src/lib/completions/generator.ts
+++ b/packages/language-server/src/lib/completions/generator.ts
@@ -107,17 +107,17 @@ function removeInvalidFieldSuggestions(
   position: Position,
 ): string[] {
   let reachedStartLine = false
-  for (const [, key, item] of schema.iterLines()) {
-    if (key === block.range.start.line + 1) {
+  for (const { lineIndex, text } of schema.iterLines()) {
+    if (lineIndex === block.range.start.line + 1) {
       reachedStartLine = true
     }
-    if (!reachedStartLine || key === position.line) {
+    if (!reachedStartLine || lineIndex === position.line) {
       continue
     }
-    if (key === block.range.end.line) {
+    if (lineIndex === block.range.end.line) {
       break
     }
-    const fieldName = item.replace(/ .*/, '')
+    const fieldName = text.replace(/ .*/, '')
     if (supportedFields.includes(fieldName)) {
       supportedFields = supportedFields.filter((field) => field !== fieldName)
     }

--- a/packages/language-server/src/lib/completions/generator.ts
+++ b/packages/language-server/src/lib/completions/generator.ts
@@ -6,6 +6,7 @@ import { convertToCompletionItems } from './internals'
 import { klona } from 'klona'
 
 import listAllAvailablePreviewFeatures from '../prisma-schema-wasm/listAllAvailablePreviewFeatures'
+import { PrismaSchema } from '../Schema'
 
 /**
  * ```prisma
@@ -102,11 +103,11 @@ function handlePreviewFeatures(
 function removeInvalidFieldSuggestions(
   supportedFields: string[],
   block: Block,
-  lines: string[],
+  schema: PrismaSchema,
   position: Position,
 ): string[] {
   let reachedStartLine = false
-  for (const [key, item] of lines.entries()) {
+  for (const [, key, item] of schema.iterLines()) {
     if (key === block.range.start.line + 1) {
       reachedStartLine = true
     }
@@ -123,14 +124,18 @@ function removeInvalidFieldSuggestions(
   }
   return supportedFields
 }
-export function getSuggestionForGeneratorField(block: Block, lines: string[], position: Position): CompletionItem[] {
+export function getSuggestionForGeneratorField(
+  block: Block,
+  schema: PrismaSchema,
+  position: Position,
+): CompletionItem[] {
   // create deep copy
   const suggestions: CompletionItem[] = klona(supportedGeneratorFields)
 
   const labels = removeInvalidFieldSuggestions(
     suggestions.map((item) => item.label),
     block,
-    lines,
+    schema,
     position,
   )
 

--- a/packages/language-server/src/lib/completions/index.ts
+++ b/packages/language-server/src/lib/completions/index.ts
@@ -635,7 +635,7 @@ export function localCompletions(
     return getSuggestionForBlockTypes(schema)
   }
 
-  if (isFirstInsideBlock(position, foundBlock.definingDocument.getUntrimmedLine(position.line))) {
+  if (isFirstInsideBlock(position, foundBlock.definingDocument.lines[position.line].untrimmedText)) {
     return getSuggestionForFirstInsideBlock(foundBlock.type, schema, position, foundBlock)
   }
 

--- a/packages/language-server/src/lib/completions/index.ts
+++ b/packages/language-server/src/lib/completions/index.ts
@@ -635,7 +635,7 @@ export function localCompletions(
     return getSuggestionForBlockTypes(schema)
   }
 
-  if (isFirstInsideBlock(position, getCurrentLine(document, position.line))) {
+  if (isFirstInsideBlock(position, foundBlock.definingDocument.getUntrimmedLine(position.line))) {
     return getSuggestionForFirstInsideBlock(foundBlock.type, schema, position, foundBlock)
   }
 

--- a/packages/language-server/src/lib/completions/types.ts
+++ b/packages/language-server/src/lib/completions/types.ts
@@ -134,10 +134,13 @@ export function getSuggestionsForFieldTypes(
     datasourceProvider === 'mongodb'
       ? getAllRelationNames(schema, relationNamesMongoDBRegexFilter)
       : getAllRelationNames(schema, relationNamesRegexFilter)
+      
   suggestions.push(...toCompletionItems(modelNames, CompletionItemKind.Reference))
+  
   const wordsBeforePosition = currentLineUntrimmed.slice(0, position.character).split(' ')
   const wordBeforePosition = wordsBeforePosition[wordsBeforePosition.length - 1]
   const completeSuggestions = suggestions.filter((s) => s.label.length === wordBeforePosition.length)
+  
   if (completeSuggestions.length !== 0) {
     for (const sugg of completeSuggestions) {
       relationSingleTypeCompletion(suggestions, sugg)

--- a/packages/language-server/src/lib/completions/types.ts
+++ b/packages/language-server/src/lib/completions/types.ts
@@ -13,6 +13,7 @@ import {
   getAllRelationNames,
 } from '../ast'
 import { relationNamesMongoDBRegexFilter, relationNamesRegexFilter } from '../constants'
+import { PrismaSchema } from '../Schema'
 
 /**
  * ```prisma
@@ -79,7 +80,7 @@ export function getNativeTypes(
 
 export function getSuggestionForNativeTypes(
   foundBlock: Block,
-  lines: string[],
+  schema: PrismaSchema,
   wordsBeforePosition: string[],
   document: TextDocument,
   onError?: (errorMessage: string) => void,
@@ -95,7 +96,7 @@ export function getSuggestionForNativeTypes(
     return undefined
   }
 
-  const datasourceName = getFirstDatasourceName(lines)
+  const datasourceName = getFirstDatasourceName(schema)
   if (!datasourceName || wordsBeforePosition[wordsBeforePosition.length - 1] !== `@${datasourceName}`) {
     return undefined
   }
@@ -111,14 +112,13 @@ export function getSuggestionForNativeTypes(
 }
 
 export function getSuggestionsForFieldTypes(
-  foundBlock: Block,
-  lines: string[],
+  schema: PrismaSchema,
   position: Position,
   currentLineUntrimmed: string,
 ): CompletionList {
   const suggestions: CompletionItem[] = []
 
-  const datasourceProvider = getFirstDatasourceProvider(lines)
+  const datasourceProvider = getFirstDatasourceProvider(schema)
   // MongoDB doesn't support Decimal
   if (datasourceProvider === 'mongodb') {
     suggestions.push(...corePrimitiveTypes.filter((s) => s.label !== 'Decimal'))
@@ -129,15 +129,12 @@ export function getSuggestionsForFieldTypes(
     suggestions.push(...corePrimitiveTypes)
   }
 
-  if (foundBlock instanceof Block) {
-    // get all model names
-    const modelNames: string[] =
-      datasourceProvider === 'mongodb'
-        ? getAllRelationNames(lines, relationNamesMongoDBRegexFilter)
-        : getAllRelationNames(lines, relationNamesRegexFilter)
-    suggestions.push(...toCompletionItems(modelNames, CompletionItemKind.Reference))
-  }
-
+  // get all model names
+  const modelNames: string[] =
+    datasourceProvider === 'mongodb'
+      ? getAllRelationNames(schema, relationNamesMongoDBRegexFilter)
+      : getAllRelationNames(schema, relationNamesRegexFilter)
+  suggestions.push(...toCompletionItems(modelNames, CompletionItemKind.Reference))
   const wordsBeforePosition = currentLineUntrimmed.slice(0, position.character).split(' ')
   const wordBeforePosition = wordsBeforePosition[wordsBeforePosition.length - 1]
   const completeSuggestions = suggestions.filter((s) => s.label.length === wordBeforePosition.length)

--- a/packages/language-server/src/lib/validations.ts
+++ b/packages/language-server/src/lib/validations.ts
@@ -25,7 +25,7 @@ export const validateExperimentalFeatures = (document: TextDocument, diagnostics
 }
 
 export const validateIgnoredBlocks = (schema: PrismaSchema, diagnostics: Diagnostic[]) => {
-  Array.from(schema.iterLines()).map(([document, lineNo, currElement]) => {
+  schema.linesAsArray().map(([document, lineNo, currElement]) => {
     if (currElement.includes('@@ignore')) {
       const block = getBlockAtPosition(document.fileUri, lineNo, schema)
       if (block) {

--- a/packages/language-server/src/lib/validations.ts
+++ b/packages/language-server/src/lib/validations.ts
@@ -3,6 +3,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 
 import { getBlockAtPosition, getExperimentalFeaturesRange } from './ast'
 import { MAX_SAFE_VALUE_i32 } from './constants'
+import { PrismaSchema } from './Schema'
 
 // TODO (Joël) can be removed? Since it was renamed to `previewFeatures`
 // check for experimentalFeatures inside generator block
@@ -23,10 +24,10 @@ export const validateExperimentalFeatures = (document: TextDocument, diagnostics
   }
 }
 
-export const validateIgnoredBlocks = (lines: string[], diagnostics: Diagnostic[]) => {
-  lines.map((currElement, index) => {
+export const validateIgnoredBlocks = (schema: PrismaSchema, diagnostics: Diagnostic[]) => {
+  Array.from(schema.iterLines()).map(([document, lineNo, currElement]) => {
     if (currElement.includes('@@ignore')) {
-      const block = getBlockAtPosition(index, lines)
+      const block = getBlockAtPosition(document.fileUri, lineNo, schema)
       if (block) {
         diagnostics.push({
           range: { start: block.range.start, end: block.range.end },
@@ -43,8 +44,8 @@ export const validateIgnoredBlocks = (lines: string[], diagnostics: Diagnostic[]
     } else if (currElement.includes('@ignore')) {
       diagnostics.push({
         range: {
-          start: { line: index, character: 0 },
-          end: { line: index, character: MAX_SAFE_VALUE_i32 },
+          start: { line: lineNo, character: 0 },
+          end: { line: lineNo, character: MAX_SAFE_VALUE_i32 },
         },
         message:
           '@ignore: When using Prisma Migrate, this field will be kept in sync with the database schema, however, it will not be exposed in Prisma Client.',

--- a/packages/language-server/src/lib/validations.ts
+++ b/packages/language-server/src/lib/validations.ts
@@ -25,9 +25,9 @@ export const validateExperimentalFeatures = (document: TextDocument, diagnostics
 }
 
 export const validateIgnoredBlocks = (schema: PrismaSchema, diagnostics: Diagnostic[]) => {
-  schema.linesAsArray().map(([document, lineNo, currElement]) => {
-    if (currElement.includes('@@ignore')) {
-      const block = getBlockAtPosition(document.fileUri, lineNo, schema)
+  schema.linesAsArray().map(({ document, lineIndex, text }) => {
+    if (text.includes('@@ignore')) {
+      const block = getBlockAtPosition(document.uri, lineIndex, schema)
       if (block) {
         diagnostics.push({
           range: { start: block.range.start, end: block.range.end },
@@ -41,11 +41,11 @@ export const validateIgnoredBlocks = (schema: PrismaSchema, diagnostics: Diagnos
           },
         })
       }
-    } else if (currElement.includes('@ignore')) {
+    } else if (text.includes('@ignore')) {
       diagnostics.push({
         range: {
-          start: { line: lineNo, character: 0 },
-          end: { line: lineNo, character: MAX_SAFE_VALUE_i32 },
+          start: { line: lineIndex, character: 0 },
+          end: { line: lineIndex, character: MAX_SAFE_VALUE_i32 },
         },
         message:
           '@ignore: When using Prisma Migrate, this field will be kept in sync with the database schema, however, it will not be exposed in Prisma Client.',


### PR DESCRIPTION
Introduces abstractions over schema files that in future would allow us to support multiple schemas files.
At the moment, this does not yet means Language tools support split schema - we are still working with a single files in there. 

Abstractions I am talking about:

- `SchemaDocument` - single `.prisma` document, part of the schema. Can be created either from `TextDocument` supplied by language tools or file read from the disk.
- `Line` - slightly nicer abstraction over single line of text, main point of it's existence - pointer back to `SchemaDocument` that contains it.
- `PrismaSchema` - collection of schema documents comprising a single DB schema. Allows to iterate over lines of all of the contained files. For the most parts, this replaces `lines: string[]` array as an input of various language tools operations.

`Block` got a pointer back to the containing documents. Renames and jumps to definition are aware that their target might not be the same file they started in and adjusted accordingly.

Close prisma/team-orm#1126