### PR TITLE
chore(ls): preview features error message wording

### DIFF
--- a/packages/language-server/src/__test__/linting/single-file.test.ts
+++ b/packages/language-server/src/__test__/linting/single-file.test.ts
@@ -104,7 +104,7 @@ describe('Linting', () => {
       [
         {
           message: `The preview feature "huh" is not known. Expected one of: ${previewFeatures.join(', ')}.
-If this is unexpected, it might be due to your Prisma VS Code Extension being out of date.`,
+If this is unexpected, it might be due to your editor's Prisma Extension being out of date.`,
           range: {
             start: { line: 2, character: 22 },
             end: { line: 2, character: 29 },

--- a/packages/language-server/src/lib/MessageHandler.ts
+++ b/packages/language-server/src/lib/MessageHandler.ts
@@ -92,7 +92,7 @@ export function handleDiagnosticsRequest(
         end: document.positionAt(diag.end),
       },
       message: previewNotKnownRegex.test(diag.text)
-        ? `${diag.text}.\nIf this is unexpected, it might be due to your Prisma VS Code Extension being out of date.`
+        ? `${diag.text}.\nIf this is unexpected, it might be due to your editor's Prisma Extension being out of date.`
         : diag.text,
       source: 'Prisma',
     }


### PR DESCRIPTION
amend wording to be inclusive of non-vscode usage

[internal slack thread](https://prisma-company.slack.com/archives/C076D0YJQQN/p1718635735239969)