### PR TITLE
chore(vscode): capture error message if electron test suite fails

### DIFF
--- a/packages/vscode/src/__test__/runTest.ts
+++ b/packages/vscode/src/__test__/runTest.ts
@@ -51,7 +51,9 @@ async function main(): Promise<void> {
       PRISMA_USE_LOCAL_LS: args[0],
     })
   } catch (err) {
-    console.error('Failed to run tests')
+    const errMsg = err instanceof Error ? ` ${err.message}` : ''
+
+    console.error(`Failed to run tests${errMsg}`)
     process.exit(1)
   }
 }


### PR DESCRIPTION
We're seeing errors in our vs code e2e test suites but we're not capturing the error message so we don't see _why_ it's erroring

https://github.com/prisma/language-tools/actions/runs/10073180669/job/27846678324
<img width="180" alt="image" src="https://github.com/user-attachments/assets/8d5e7c6b-96d5-405f-af9b-76213c24275c">
