### PR TITLE
chore: fix typo in vscode/src/util.ts

### DIFF
--- a/packages/vscode/src/util.ts
+++ b/packages/vscode/src/util.ts
@@ -26,7 +26,7 @@ export function checkForOtherPrismaExtension(): void {
   if (files.length !== 0) {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     window.showInformationMessage(
-      `You have both both versions (Insider and Stable) of the Prisma VS Code extension enabled in your workspace. Please uninstall or disable one of them for a better experience.`,
+      `You have both versions (Insider and Stable) of the Prisma VS Code extension enabled in your workspace. Please uninstall or disable one of them for a better experience.`,
     )
     console.log('Both versions (Insider and Stable) of the Prisma VS Code extension are enabled.')
   }


### PR DESCRIPTION
there is a minor repetition error in the sentence. The word “both” is repeated twice.