### PR TITLE
chore: bump minimal supported VSCode version from 1.56 to 1.85

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/glob": "8.1.0",
         "@types/mocha": "10.0.6",
-        "@types/vscode": "1.56.0",
+        "@types/vscode": "1.85.0",
         "@vscode/test-electron": "2.4.1",
         "@vscode/vsce": "2.29.0",
         "is-ci": "3.0.1",
@@ -28,7 +28,7 @@
         "typescript": "5.5.3"
       },
       "engines": {
-        "vscode": "^1.56.0"
+        "vscode": "^1.85.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -311,10 +311,11 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
-      "dev": true
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vscode/test-electron": {
       "version": "2.4.1",
@@ -4120,9 +4121,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true
     },
     "@vscode/test-electron": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "icon": "logo_white.png",
   "engines": {
-    "vscode": "^1.56.0"
+    "vscode": "^1.85.0"
   },
   "publisher": "Prisma",
   "categories": [
@@ -184,7 +184,7 @@
   "devDependencies": {
     "@types/glob": "8.1.0",
     "@types/mocha": "10.0.6",
-    "@types/vscode": "1.56.0",
+    "@types/vscode": "1.85.0",
     "@vscode/test-electron": "2.4.1",
     "is-ci": "3.0.1",
     "mocha": "10.6.0",


### PR DESCRIPTION
Bump the minimal supported VSCode version from 1.56 (April 2021) to 1.85
(November 2023). This fixes the e2e tests.
