### PR TITLE
fix(vscode): fix syntax highlightning

### DIFF
--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -392,8 +392,8 @@
       "name": "comment.prisma"
     },
     "multi_line_comment": {
-      "begin": "/*",
-      "end": "*/",
+      "begin": "/\\*",
+      "end": "\\*/",
       "name": "comment.prisma"
     },
     "double_comment_inline": {


### PR DESCRIPTION
This PR follows up https://github.com/prisma/language-tools/pull/1806 ([see Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1734381823284309)).