### PR TITLE
fix: prevent double version bumps

### DIFF
--- a/.github/workflows/2_bump_versions.yml
+++ b/.github/workflows/2_bump_versions.yml
@@ -40,13 +40,13 @@ jobs:
 
       - name: Update versions file in scripts folder
         run: |
-          VERSION_FILE="scripts/versions/prisma_${{ github.event.inputs.npm_channel }}"
-          if [[ "${{ github.event.inputs.version }}" == $(cat $VERSION_FILE) ]]; then
+          echo "${{ github.event.inputs.version }}" >scripts/versions/prisma_${{ github.event.inputs.npm_channel }}
+
+          if git diff --exit-code; then
             echo "Version has not changed! We should not attempt to bump."
             exit 1
           fi
-          
-          echo "${{ github.event.inputs.version }}" > $VERSION_FILE
+
       - name: Update next extension version in scripts folder and output for later use
         id: update # Used to access the calculated next extension version in later steps
         run: node scripts/bump_extension_version.js ${{ github.event.inputs.npm_channel }}

--- a/.github/workflows/2_bump_versions.yml
+++ b/.github/workflows/2_bump_versions.yml
@@ -40,7 +40,13 @@ jobs:
 
       - name: Update versions file in scripts folder
         run: |
-          echo "${{ github.event.inputs.version }}" >scripts/versions/prisma_${{ github.event.inputs.npm_channel }}
+          VERSION_FILE="scripts/versions/prisma_${{ github.event.inputs.npm_channel }}"
+          if [[ "${{ github.event.inputs.version }}" == $(cat $VERSION_FILE) ]]; then
+            echo "Version has not changed! We should not attempt to bump."
+            exit 1
+          fi
+          
+          echo "${{ github.event.inputs.version }}" > $VERSION_FILE
       - name: Update next extension version in scripts folder and output for later use
         id: update # Used to access the calculated next extension version in later steps
         run: node scripts/bump_extension_version.js ${{ github.event.inputs.npm_channel }}


### PR DESCRIPTION
A double version bump can currently occur when the prisma CLI update check succeeds twice for the same version and spawns two bump version jobs. It can happen because the job runs on a 5 minute cron (and the cron is not reliable, it run twice within 2 minutes yesterday).
Normally git would prevent one from the bump commits from being pushed, but if the two bump jobs end up checking out and pushing one after another they maintain linear history and successfully push two version bumps. This is easy to prevent though - we can check if the version we intend to bump to is already in the file. If it is, then some job has bumped it before us and if it hasn't happened yet the two jobs will race and only one will successfully `git push`.