### PR TITLE
feat(query compiler): add client engine type to completions

### DIFF
--- a/packages/language-server/src/__test__/completions/single-file.test.ts
+++ b/packages/language-server/src/__test__/completions/single-file.test.ts
@@ -588,6 +588,10 @@ describe('Completions', function () {
               label: 'binary',
               kind: CompletionItemKind.Constant,
             },
+            {
+              label: 'client',
+              kind: CompletionItemKind.Constant,
+            },
           ],
         },
       })

--- a/packages/language-server/src/lib/completions/completions.json
+++ b/packages/language-server/src/lib/completions/completions.json
@@ -406,7 +406,7 @@
     },
     {
       "label": "client",
-      "documentation": "TypeScript based query execution. Node-API library for query compilation."
+      "documentation": "TypeScript based query execution. WebAssembly library for query compilation."
     }
   ],
   "engineTypeArguments": [

--- a/packages/language-server/src/lib/completions/completions.json
+++ b/packages/language-server/src/lib/completions/completions.json
@@ -98,7 +98,7 @@
       "label": "engineType",
       "insertText": "engineType = \"$0\"",
       "documentation": "Defines the query engine type for Prisma Client. Default: `library`. [Learn more](https://pris.ly/d/client-engine-type).",
-      "fullSignature": "engineType = \"library\" | \"binary\""
+      "fullSignature": "engineType = \"library\" | \"binary\" | \"client\""
     },
     {
       "label": "binaryTargets",
@@ -403,6 +403,10 @@
     {
       "label": "binary",
       "documentation": "Executable binary."
+    },
+    {
+      "label": "client",
+      "documentation": "TypeScript based query execution. Node-API library for query compilation."
     }
   ],
   "engineTypeArguments": [


### PR DESCRIPTION
Adding syntax support for the new engine type `client`. See https://github.com/prisma/prisma/pull/26092

> [!WARNING]
> Should only be merged once we actually merge and ship the query compiler. ;) 