### PR TITLE
fix(vscode): fix activation events

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -35,10 +35,7 @@
   "main": "./dist/src/extension.js",
   "activationEvents": [
     "onLanguage:prisma",
-    "onLanguage:javascript",
-    "onLanguage:javascriptreact",
-    "onLanguage:typescript",
-    "onLanguage:typescriptreact"
+    "workspaceContains:**/*.prisma"
   ],
   "contributes": {
     "languages": [


### PR DESCRIPTION
Currently the extension is activated every time that a javascript or typescript file is opened, even if no related prisms file is present in the workspace...

With this PR, the extension is activated when a  file with `prisma` extension is opened or exists in the workspace

Fix https://github.com/prisma/language-tools/issues/1815
