### PR TITLE
feat: add ULID and NanoID completions to language server

### DIFF
--- a/packages/language-server/src/__test__/completions/single-file.test.ts
+++ b/packages/language-server/src/__test__/completions/single-file.test.ts
@@ -2183,6 +2183,14 @@ describe('Completions', function () {
       label: 'uuid()',
       kind: CompletionItemKind.Function,
     }
+    const functionUlid = {
+      label: 'ulid()',
+      kind: CompletionItemKind.Function,
+    }
+    const functionNanoid = {
+      label: 'nanoid()',
+      kind: CompletionItemKind.Function,
+    }
     const functionAuto = {
       label: 'auto()',
       kind: CompletionItemKind.Function,
@@ -2543,7 +2551,7 @@ describe('Completions', function () {
                 }`,
             expected: {
               isIncomplete: false,
-              items: [functionDbGenerated, functionUuid, functionCuid],
+              items: [functionDbGenerated, functionUuid, functionCuid, functionUlid, functionNanoid],
             },
           })
         })
@@ -2620,7 +2628,7 @@ describe('Completions', function () {
             }`,
             expected: {
               isIncomplete: false,
-              items: [functionAuto, functionUuid, functionCuid],
+              items: [functionAuto, functionUuid, functionCuid, functionUlid, functionNanoid],
             },
           })
         })
@@ -2660,7 +2668,7 @@ describe('Completions', function () {
             }`,
             expected: {
               isIncomplete: false,
-              items: [functionAuto, functionUuid, functionCuid],
+              items: [functionAuto, functionUuid, functionCuid, functionUlid, functionNanoid],
             },
           })
         })

--- a/packages/language-server/src/lib/completions/functions.ts
+++ b/packages/language-server/src/lib/completions/functions.ts
@@ -71,6 +71,26 @@ export const cuidDefaultCompletion = (items: CompletionItem[]) =>
     },
   })
 
+export const ulidDefaultCompletion = (items: CompletionItem[]) =>
+  items.push({
+    label: 'ulid()',
+    kind: CompletionItemKind.Function,
+    documentation: {
+      kind: MarkupKind.Markdown,
+      value: 'Generate a universally unique lexicographically sortable identifier based on the [ULID](https://github.com/ulid/spec) spec.',
+    },
+  })
+
+export const nanoidDefaultCompletion = (items: CompletionItem[]) =>
+  items.push({
+    label: 'nanoid()',
+    kind: CompletionItemKind.Function,
+    documentation: {
+      kind: MarkupKind.Markdown,
+      value: 'Generate a secure, URL-friendly, unique identifier based on the [nanoid](https://github.com/ai/nanoid) spec. The length is customizable, defaults to 21.',
+    },
+  })
+
 export const nativeFunctionCompletion = (
   items: CompletionItem[],
   element: NativeTypeConstructors,

--- a/packages/language-server/src/lib/completions/index.ts
+++ b/packages/language-server/src/lib/completions/index.ts
@@ -60,6 +60,8 @@ import {
   nowDefaultCompletion,
   uuidDefaultCompletion,
   cuidDefaultCompletion,
+  ulidDefaultCompletion,
+  nanoidDefaultCompletion,
 } from './functions'
 import { BlockType } from '../types'
 import { PrismaSchema } from '../Schema'
@@ -143,6 +145,8 @@ function getDefaultValues({
     case 'String':
       uuidDefaultCompletion(suggestions)
       cuidDefaultCompletion(suggestions)
+      ulidDefaultCompletion(suggestions)
+      nanoidDefaultCompletion(suggestions)
       break
     case 'Boolean':
       booleanDefaultCompletions(suggestions)


### PR DESCRIPTION
I noticed they where missing in the vscode extension.