### PR TITLE
chore: revert "fix: update expected format (#1830)"

### DIFF
--- a/packages/vscode/fixtures/format/expected.prisma
+++ b/packages/vscode/fixtures/format/expected.prisma
@@ -24,6 +24,8 @@ model User {
 }
 
 model PostTitle {
-  id    Int    @id @default(autoincrement())
-  title String
+  id     Int    @id @default(autoincrement())
+  title  String
+  Post   Post?  @relation(fields: [postId], references: [id])
+  postId Int?
 }


### PR DESCRIPTION
Reverts the assertion change because it seems to be a legitimate bug