### PR TITLE
feat: ORM-934 add oauth login

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@types/glob": "8.1.0",
         "@types/mocha": "10.0.10",
+        "@types/node": "20.14.8",
         "@types/vscode": "1.96.0",
         "@vscode/test-electron": "2.4.1",
         "@vscode/vsce": "2.29.0",
@@ -412,10 +413,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
-      "dev": true
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/vscode": {
       "version": "1.96.0",
@@ -4144,6 +4149,13 @@
       "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -4910,10 +4922,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.3.tgz",
-      "integrity": "sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==",
-      "dev": true
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/vscode": {
       "version": "1.96.0",
@@ -7681,6 +7696,12 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
       "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "universalify": {

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -535,6 +535,7 @@
     "@types/glob": "8.1.0",
     "@types/mocha": "10.0.10",
     "@types/vscode": "1.96.0",
+    "@types/node": "20.14.8",
     "@vscode/test-electron": "2.4.1",
     "is-ci": "3.0.1",
     "mocha": "10.8.2",

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/login.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/login.ts
@@ -1,10 +1,12 @@
 import { commands } from 'vscode'
 import { PrismaPostgresRepository } from '../PrismaPostgresRepository'
+import { Auth } from '../management-api/auth'
 
-export const login = async (ppgRepository: PrismaPostgresRepository) => {
+export const login = async (ppgRepository: PrismaPostgresRepository, auth: Auth) => {
   if ((await ppgRepository.getWorkspaces()).length === 0) {
     await commands.executeCommand('setContext', 'prisma.initialLoginInProgress', true)
   }
-  await ppgRepository.workspaceLogin()
+  await auth.login()
+  await ppgRepository.workspaceLogin() // TODO: remove this once actual api connected
   await commands.executeCommand('setContext', 'prisma.initialLoginInProgress', false)
 }

--- a/packages/vscode/src/plugins/prisma-postgres-manager/management-api/auth.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/management-api/auth.ts
@@ -1,0 +1,100 @@
+import * as crypto from 'crypto'
+import { Uri, env } from 'vscode'
+
+const CLIENT_ID = 'cmamnw2go00005812nlbzb4pi'
+const LOGIN_URL = 'https://auth.prisma.io/authorize'
+const TOKEN_URL = 'https://auth.prisma.io/token'
+
+export type AuthResult = {
+  token: string
+}
+
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AuthError'
+  }
+}
+
+export class Auth {
+  private latestVerifier?: string
+  private latestState?: string
+
+  constructor(private readonly extensionId: string) {}
+
+  async login() {
+    this.latestState = this.generateState()
+    this.latestVerifier = this.generateVerifier()
+    const challenge = this.generateChallenge(this.latestVerifier)
+
+    const authUrl = new URL(LOGIN_URL)
+    authUrl.searchParams.set('response_type', 'code')
+    authUrl.searchParams.set('client_id', CLIENT_ID)
+    authUrl.searchParams.set('redirect_uri', this.getRedirectUri())
+    authUrl.searchParams.set('scope', 'workspace:admin offline_access')
+    authUrl.searchParams.set('state', this.latestState)
+    authUrl.searchParams.set('code_challenge', challenge)
+    authUrl.searchParams.set('code_challenge_method', 'S256')
+
+    await env.openExternal(Uri.parse(authUrl.toString()))
+  }
+
+  async handleCallback(uri: Uri): Promise<AuthResult | null> {
+    if (uri.path !== '/auth/callback') return null
+
+    const code = new URLSearchParams(uri.query).get('code')
+    const state = new URLSearchParams(uri.query).get('state')
+    if (!code) throw new AuthError('No code found in callback')
+    if (!this.latestVerifier) throw new AuthError('No verifier found')
+    if (state !== this.latestState) throw new AuthError('Invalid state')
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: this.getRedirectUri(),
+      client_id: CLIENT_ID,
+      code_verifier: this.latestVerifier,
+    })
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body,
+    })
+
+    const data = await response.json()
+
+    if (response.status !== 200) throw new AuthError(`Received status code ${response.status} from token endpoint`)
+    if (
+      !data ||
+      typeof data !== 'object' ||
+      !('access_token' in data) ||
+      !data.access_token ||
+      typeof data.access_token !== 'string'
+    ) {
+      throw new AuthError('No access token received in token endpoint response')
+    }
+
+    return { token: data.access_token }
+  }
+
+  private getRedirectUri(): string {
+    return `${env.uriScheme}://${this.extensionId.toLowerCase()}/auth/callback`
+  }
+
+  private base64urlEncode(buffer: Buffer): string {
+    return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  }
+
+  private generateState(): string {
+    return crypto.randomBytes(16).toString('hex')
+  }
+
+  private generateVerifier(): string {
+    return this.base64urlEncode(crypto.randomBytes(32))
+  }
+
+  private generateChallenge(verifier: string): string {
+    const hash = crypto.createHash('sha256').update(verifier).digest()
+    return this.base64urlEncode(hash)
+  }
+}


### PR DESCRIPTION
This PR just adds the basic OAuth handling. Storing and using the tokens is coming in an upcoming PR that also connects in the API.

Note that refresh token handling is also a pending task and not yet supported by the backend.

Note: Targeting `manage-ppg` branch for now so we can still release ORM hotfixes without reverting work for the manage ppg extension.