### PR TITLE
chore(api-types): add missing git credentials step

### DIFF
--- a/.github/workflows/update-api-types.yml
+++ b/.github/workflows/update-api-types.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Install Dependencies
         run: npm install && npm run bootstrap
 
+      - name: Setup Git
+        run: |
+          sh scripts/set_git_credentials.sh
+
       - name: Generate API client
         working-directory: packages/vscode
         run: npm run generate-api-client


### PR DESCRIPTION
Workflow is currently failing due to missing git credentials. This script is already used by the other workflows that bump versions.

Tested workflow run here: https://github.com/prisma/language-tools/actions/runs/15133313479 (force pushed this branch afterwards to revert changes done by the workflow - wanna test this on main then again ;) )