### PR TITLE
fix: use stable zod version 3.24.3

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -22,7 +22,7 @@
         "openapi-fetch": "0.14.0",
         "vscode-languageclient": "7.0.0",
         "watcher": "1.2.0",
-        "zod": "3.25.13"
+        "zod": "3.24.3"
       },
       "devDependencies": {
         "@types/glob": "8.1.0",
@@ -5092,9 +5092,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.13.tgz",
-      "integrity": "sha512-Q8mvk2iWi7rTDfpQBsu4ziE7A6AxgzJ5hzRyRYQkoV3A3niYsXVwDaP1Kbz3nWav6S+VZ6k2OznFn8ZyDHvIrg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -8871,9 +8871,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.25.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.13.tgz",
-      "integrity": "sha512-Q8mvk2iWi7rTDfpQBsu4ziE7A6AxgzJ5hzRyRYQkoV3A3niYsXVwDaP1Kbz3nWav6S+VZ6k2OznFn8ZyDHvIrg=="
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="
     }
   }
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -26,7 +26,7 @@
     "openapi-fetch": "0.14.0",
     "vscode-languageclient": "7.0.0",
     "watcher": "1.2.0",
-    "zod": "3.25.13"
+    "zod": "3.24.3"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
zod v3.25.x which includes the new zod v4 stuff seems to be very unstable and breaks our build. They also issues 20 patch releases for 3.25 in the last 48h. As it seems not a safe bet to use this yet. Espeically not in our non-esm project here. Switching back to an older more stable version for now.