### PR TITLE
feat: ORM-998 launch studio for default ppg dev

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -22,7 +22,7 @@
         "openapi-fetch": "0.14.0",
         "vscode-languageclient": "7.0.0",
         "watcher": "1.2.0",
-        "zod": "3.25.13"
+        "zod": "3.24.3"
       },
       "devDependencies": {
         "@types/glob": "8.1.0",
@@ -5092,9 +5092,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.13.tgz",
-      "integrity": "sha512-Q8mvk2iWi7rTDfpQBsu4ziE7A6AxgzJ5hzRyRYQkoV3A3niYsXVwDaP1Kbz3nWav6S+VZ6k2OznFn8ZyDHvIrg==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -8871,9 +8871,9 @@
       "dev": true
     },
     "zod": {
-      "version": "3.25.13",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.13.tgz",
-      "integrity": "sha512-Q8mvk2iWi7rTDfpQBsu4ziE7A6AxgzJ5hzRyRYQkoV3A3niYsXVwDaP1Kbz3nWav6S+VZ6k2OznFn8ZyDHvIrg=="
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="
     }
   }
 }

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -26,7 +26,7 @@
     "openapi-fetch": "0.14.0",
     "vscode-languageclient": "7.0.0",
     "watcher": "1.2.0",
-    "zod": "3.25.13"
+    "zod": "3.24.3"
   },
   "repository": {
     "type": "git",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -254,6 +254,12 @@
         "title": "Launch Prisma Studio",
         "category": "Prisma",
         "icon": "$(link-external)"
+      },
+      {
+        "command": "prisma.studio.launchForDatabase",
+        "title": "Launch Prisma Studio",
+        "category": "Prisma",
+        "icon": "$(link-external)"
       }
     ],
     "languageModelTools": [
@@ -483,6 +489,10 @@
         },
         {
           "command": "prisma.openRemoteDatabaseInPrismaConsole",
+          "when": "false"
+        },
+        {
+          "command": "prisma.studio.launchForDatabase",
           "when": "false"
         }
       ],

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -232,6 +232,12 @@
         "category": "Prisma"
       },
       {
+        "command": "prisma.getRemoteDatabaseConnectionString",
+        "title": "Get Connection String",
+        "icon": "$(shield)",
+        "category": "Prisma"
+      },
+      {
         "command": "prisma.openRemoteDatabaseInPrismaConsole",
         "title": "Open Remote Prisma Postgres Database in Prisma Console",
         "icon": "$(link-external)",
@@ -524,6 +530,10 @@
           "command": "prisma.openRemoteDatabaseInPrismaConsole",
           "when": "viewItem == prismaRemoteDatabaseItem",
           "group": "inline"
+        },
+        {
+          "command": "prisma.getRemoteDatabaseConnectionString",
+          "when": "viewItem == prismaRemoteDatabaseItem"
         }
       ]
     },

--- a/packages/vscode/src/plugins/prisma-postgres-manager/ConnectionStringStorage.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/ConnectionStringStorage.ts
@@ -1,0 +1,120 @@
+import type { SecretStorage } from 'vscode'
+import z from 'zod'
+
+// Storing connection strings in this JSON structure under a single key in the secret storage.
+// This allows for easy deletion of multiple entries when a project is deleted or the user logs out from a workspace.
+const StoredConnectionStringsSchema = z.object({
+  workspaces: z.record(
+    z.string(), // workspaceId
+    z.object({
+      projects: z.record(
+        z.string(), // projectId
+        z.object({
+          databases: z.record(
+            z.string(), // databaseId
+            z.object({
+              connectionString: z.string(),
+            }),
+          ),
+        }),
+      ),
+    }),
+  ),
+})
+
+type StoredConnectionStrings = z.infer<typeof StoredConnectionStringsSchema>
+
+const STORED_CREDENTIALS_KEY = 'prisma-postgres.connection-strings'
+
+export class ConnectionStringStorage {
+  constructor(private readonly vscodeSecretStorage: SecretStorage) {}
+
+  async storeConnectionString({
+    workspaceId,
+    projectId,
+    databaseId,
+    connectionString,
+  }: {
+    workspaceId: string
+    projectId: string
+    databaseId: string
+    connectionString: string
+  }): Promise<void> {
+    const storage = await this.getStoredConnectionStrings()
+
+    const updatedStorage: StoredConnectionStrings = {
+      ...storage,
+      workspaces: {
+        ...storage.workspaces,
+        [workspaceId]: {
+          ...storage.workspaces[workspaceId],
+          projects: {
+            ...storage.workspaces[workspaceId]?.projects,
+            [projectId]: {
+              ...storage.workspaces[workspaceId]?.projects[projectId],
+              databases: {
+                ...storage.workspaces[workspaceId]?.projects[projectId]?.databases,
+                [databaseId]: {
+                  connectionString,
+                },
+              },
+            },
+          },
+        },
+      },
+    }
+
+    await this.storeConnectionStrings(updatedStorage)
+  }
+
+  async getConnectionString({
+    workspaceId,
+    projectId,
+    databaseId,
+  }: {
+    workspaceId: string
+    projectId: string
+    databaseId: string
+  }): Promise<string | undefined> {
+    const storage = await this.getStoredConnectionStrings()
+    return storage.workspaces[workspaceId]?.projects[projectId]?.databases[databaseId]?.connectionString
+  }
+
+  async removeConnectionString({
+    workspaceId,
+    projectId,
+    databaseId,
+  }: {
+    workspaceId: string
+    projectId?: string
+    databaseId?: string
+  }): Promise<void> {
+    const storage = await this.getStoredConnectionStrings()
+
+    if (databaseId && projectId) {
+      delete storage.workspaces[workspaceId].projects[projectId].databases[databaseId]
+    } else if (databaseId && !projectId) {
+      throw new Error('When databaseId is provided, projectId is required')
+    } else if (projectId) {
+      delete storage.workspaces[workspaceId].projects[projectId]
+    } else {
+      delete storage.workspaces[workspaceId]
+    }
+
+    await this.storeConnectionStrings(storage)
+  }
+
+  private async storeConnectionStrings(connectionStrings: StoredConnectionStrings): Promise<void> {
+    await this.vscodeSecretStorage.store(STORED_CREDENTIALS_KEY, JSON.stringify(connectionStrings))
+  }
+
+  private async getStoredConnectionStrings(): Promise<StoredConnectionStrings> {
+    try {
+      const storedCredentials = await this.vscodeSecretStorage.get(STORED_CREDENTIALS_KEY)
+      return StoredConnectionStringsSchema.parse(JSON.parse(storedCredentials || '{ "workspaces": {} }'))
+    } catch (error) {
+      console.error('Error getting stored connection strings', error)
+      return { workspaces: {} }
+    }
+  }
+}

--- a/packages/vscode/src/plugins/prisma-postgres-manager/PrismaPostgresRepository.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/PrismaPostgresRepository.ts
@@ -40,9 +40,22 @@ export function isRemoteDatabase(item: unknown): item is RemoteDatabase {
   return typeof item === 'object' && item !== null && 'type' in item && item.type === 'remoteDatabase'
 }
 
+export type LocalDatabase = {
+  type: 'localDatabase'
+}
+export function isLocalDatabase(item: unknown): item is LocalDatabase {
+  return typeof item === 'object' && item !== null && 'type' in item && item.type === 'localDatabase'
+}
+
 export type NewlyCreatedDatabase = RemoteDatabase & { connectionString: string }
 
-export type PrismaPostgresItem = { type: 'remoteRoot' } | Workspace | Project | RemoteDatabase
+export type PrismaPostgresItem =
+  | { type: 'localRoot' }
+  | { type: 'remoteRoot' }
+  | Workspace
+  | Project
+  | RemoteDatabase
+  | LocalDatabase
 
 export interface PrismaPostgresRepository {
   readonly refreshEventEmitter: EventEmitter<void | PrismaPostgresItem>

--- a/packages/vscode/src/plugins/prisma-postgres-manager/PrismaPostgresTreeDataProvider.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/PrismaPostgresTreeDataProvider.ts
@@ -133,4 +133,10 @@ class PrismaRemoteDatabaseItem extends vscode.TreeItem {
   iconPath = new vscode.ThemeIcon('database')
 
   contextValue = 'prismaRemoteDatabaseItem'
+
+  command = {
+    command: 'prisma.studio.launchForDatabase',
+    title: 'Launch Prisma Studio',
+    arguments: [{ workspaceId: this.workspaceId, projectId: this.projectId, databaseId: this.databaseId }],
+  }
 }

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/getRemoteDatabaseConnectionString.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/getRemoteDatabaseConnectionString.ts
@@ -23,7 +23,7 @@ export const getRemoteDatabaseConnectionString = async (ppgRepository: PrismaPos
   const result = await window.showInformationMessage(
     `Create Connection String`,
     {
-      detail: `No locally stored connection string found for remote database ${args.name}.\nDo you want to create a new connection string?`,
+      detail: `No locally stored connection string found for remote database ${args.name}.\n\nDo you want to create a new connection string?`,
       modal: true,
     },
     { id: 'create', title: 'Create connection string', isCloseAffordance: false },

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/getRemoteDatabaseConnectionString.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/getRemoteDatabaseConnectionString.ts
@@ -1,0 +1,53 @@
+import { ProgressLocation, window } from 'vscode'
+import { isRemoteDatabase, PrismaPostgresRepository } from '../PrismaPostgresRepository'
+import { presentConnectionString } from '../shared-ui/connectionStringMessage'
+
+export const getRemoteDatabaseConnectionString = async (ppgRepository: PrismaPostgresRepository, args: unknown) => {
+  if (!isRemoteDatabase(args)) throw new Error('Invalid arguments')
+
+  const connectionString = await ppgRepository.getStoredRemoteDatabaseConnectionString({
+    workspaceId: args.workspaceId,
+    projectId: args.projectId,
+    databaseId: args.id,
+  })
+
+  if (connectionString) {
+    void presentConnectionString({
+      name: args.name,
+      region: args.region,
+      connectionString,
+    })
+    return
+  }
+
+  const result = await window.showInformationMessage(
+    `Create Connection String`,
+    {
+      detail: `No locally stored connection string found for remote database ${args.name}.\nDo you want to create a new connection string?`,
+      modal: true,
+    },
+    { id: 'create', title: 'Create connection string', isCloseAffordance: false },
+    { id: 'cancel', title: 'Cancel', isCloseAffordance: true },
+  )
+
+  if (result?.id === 'cancel') return
+
+  const createdConnectionString = await window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: `Creating connection string for database '${args.name}'...`,
+    },
+    () =>
+      ppgRepository.createRemoteDatabaseConnectionString({
+        workspaceId: args.workspaceId,
+        projectId: args.projectId,
+        databaseId: args.id,
+      }),
+  )
+
+  void presentConnectionString({
+    name: args.name,
+    region: args.region,
+    connectionString: createdConnectionString,
+  })
+}

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/launchStudio.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/launchStudio.ts
@@ -1,0 +1,63 @@
+import { ExtensionContext, ProgressLocation, window } from 'vscode'
+import { PrismaPostgresRepository } from '../PrismaPostgresRepository'
+import { z } from 'zod'
+import { launch } from '../../prisma-studio/commands/launch'
+
+export const launchStudioForRemoteDatabase = async ({
+  ppgRepository,
+  context,
+  args,
+}: {
+  ppgRepository: PrismaPostgresRepository
+  context: ExtensionContext
+  args: unknown
+}) => {
+  const database = z
+    .object({
+      workspaceId: z.string(),
+      projectId: z.string(),
+      databaseId: z.string(),
+    })
+    .parse(args)
+
+  const connectionString = await getConnectionString(ppgRepository, database)
+
+  if (!connectionString) return
+
+  void launch({ dbUrl: connectionString, context })
+}
+
+const getConnectionString = async (
+  ppgRepository: PrismaPostgresRepository,
+  database: {
+    workspaceId: string
+    projectId: string
+    databaseId: string
+  },
+) => {
+  const connectionString = await ppgRepository.getStoredRemoteDatabaseConnectionString(database)
+
+  if (connectionString) return connectionString
+
+  const result = await window.showInformationMessage(
+    `Create Connection String`,
+    {
+      detail: `To open Studio with this database a connection string is required but no locally stored connection string was found.\n\nDo you want to create a new connection string?`,
+      modal: true,
+    },
+    { id: 'create', title: 'Create connection string', isCloseAffordance: false },
+    { id: 'cancel', title: 'Cancel', isCloseAffordance: true },
+  )
+
+  if (result?.id !== 'create') return undefined
+
+  const createdConnectionString = await window.withProgress(
+    {
+      location: ProgressLocation.Notification,
+      title: `Creating connection string for database...`,
+    },
+    () => ppgRepository.createRemoteDatabaseConnectionString(database),
+  )
+
+  return createdConnectionString
+}

--- a/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
@@ -11,7 +11,7 @@ import { login, handleAuthCallback } from './commands/login'
 import { Auth } from './management-api/auth'
 import { ConnectionStringStorage } from './ConnectionStringStorage'
 import { getRemoteDatabaseConnectionString } from './commands/getRemoteDatabaseConnectionString'
-import { launchStudioForRemoteDatabase } from './commands/launchStudio'
+import { launchStudio } from './commands/launchStudio'
 
 export default {
   name: 'Prisma Postgres',
@@ -76,9 +76,7 @@ export default {
         await handleCommandError('Delete Remote Database', () => deleteRemoteDatabase(ppgRepository, args))
       }),
       commands.registerCommand('prisma.studio.launchForDatabase', async (args: unknown) => {
-        await handleCommandError('Launch Studio for Database', () =>
-          launchStudioForRemoteDatabase({ ppgRepository, args, context }),
-        )
+        await handleCommandError('Launch Studio for Database', () => launchStudio({ ppgRepository, args, context }))
       }),
     )
   },

--- a/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
@@ -9,6 +9,8 @@ import { handleCommandError } from './shared-ui/handleCommandError'
 import { logout } from './commands/logout'
 import { login, handleAuthCallback } from './commands/login'
 import { Auth } from './management-api/auth'
+import { ConnectionStringStorage } from './ConnectionStringStorage'
+import { getRemoteDatabaseConnectionString } from './commands/getRemoteDatabaseConnectionString'
 
 export default {
   name: 'Prisma Postgres',
@@ -17,7 +19,8 @@ export default {
   },
   activate(context: ExtensionContext) {
     const auth = new Auth(context.extension.id)
-    const ppgRepository = new PrismaPostgresApiRepository(auth)
+    const connectionStringStorage = new ConnectionStringStorage(context.secrets)
+    const ppgRepository = new PrismaPostgresApiRepository(auth, connectionStringStorage)
     const ppgProvider = new PrismaPostgresTreeDataProvider(ppgRepository)
 
     window.registerUriHandler({
@@ -53,6 +56,11 @@ export default {
       }),
       commands.registerCommand('prisma.createRemoteDatabase', async (args: unknown) => {
         await handleCommandError('Create Remote Database', () => createRemoteDatabase(ppgRepository, args))
+      }),
+      commands.registerCommand('prisma.getRemoteDatabaseConnectionString', async (args: unknown) => {
+        await handleCommandError('Get Remote Database Connection String', () =>
+          getRemoteDatabaseConnectionString(ppgRepository, args),
+        )
       }),
       commands.registerCommand('prisma.openRemoteDatabaseInPrismaConsole', async (args: unknown) => {
         if (isRemoteDatabase(args)) {

--- a/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
@@ -11,6 +11,7 @@ import { login, handleAuthCallback } from './commands/login'
 import { Auth } from './management-api/auth'
 import { ConnectionStringStorage } from './ConnectionStringStorage'
 import { getRemoteDatabaseConnectionString } from './commands/getRemoteDatabaseConnectionString'
+import { launchStudioForRemoteDatabase } from './commands/launchStudio'
 
 export default {
   name: 'Prisma Postgres',
@@ -73,6 +74,11 @@ export default {
       }),
       commands.registerCommand('prisma.deleteRemoteDatabase', async (args: unknown) => {
         await handleCommandError('Delete Remote Database', () => deleteRemoteDatabase(ppgRepository, args))
+      }),
+      commands.registerCommand('prisma.studio.launchForDatabase', async (args: unknown) => {
+        await handleCommandError('Launch Studio for Database', () =>
+          launchStudioForRemoteDatabase({ ppgRepository, args, context }),
+        )
       }),
     )
   },


### PR DESCRIPTION
This PR adds an entry for the default local ppg dev database to connect studio to it.
<img width="298" alt="Screenshot 2025-05-22 at 12 33 23" src="https://github.com/user-attachments/assets/0b45195d-b63e-4a5e-8540-5ca303cdfd4e" />

> [!NOTE]
> This PR is based upon https://github.com/prisma/language-tools/pull/1858 and targeting it as merge target to highlight the correct changes. That PR should be merged first.