### PR TITLE
feat: ORM-992 streamline copy and error messages

### DIFF
--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -191,19 +191,19 @@
       },
       {
         "command": "prisma.refresh",
-        "title": "Refresh Database List",
+        "title": "Refresh Prisma Postgres List",
         "icon": "$(refresh)",
         "category": "Prisma"
       },
       {
         "command": "prisma.login",
-        "title": "Login to Workspace",
+        "title": "Login to Prisma Platform Workspace",
         "icon": "$(sign-in)",
         "category": "Prisma"
       },
       {
         "command": "prisma.logout",
-        "title": "Logout from Workspace",
+        "title": "Logout from Prisma Platform Workspace",
         "icon": "$(sign-out)",
         "category": "Prisma"
       },
@@ -215,7 +215,7 @@
       },
       {
         "command": "prisma.deleteProject",
-        "title": "Delete Project",
+        "title": "Delete Prisma Postgres Project",
         "icon": "$(trash)",
         "category": "Prisma"
       },
@@ -239,13 +239,13 @@
       },
       {
         "command": "prisma.openRemoteDatabaseInPrismaConsole",
-        "title": "Open in Prisma Console",
+        "title": "Open Remote Prisma Postgres Database in Prisma Console",
         "icon": "$(link-external)",
         "category": "Prisma"
       },
       {
         "command": "prisma.deleteRemoteDatabase",
-        "title": "Delete Database",
+        "title": "Delete Remote Prisma Postgres Database",
         "icon": "$(trash)",
         "category": "Prisma"
       },
@@ -371,30 +371,6 @@
         }
       },
       {
-        "name": "prisma-platform-auth-status",
-        "tags": [
-          "prisma",
-          "database",
-          "ppg",
-          "postgres"
-        ],
-        "toolReferenceName": "prisma-platform-auth-status",
-        "displayName": "Prisma Platform Auth Status",
-        "modelDescription": "Prisma Platform Auth Status provides information about the currently logged in user. If the user is not logged in, you should instruct them to do so by using the `prisma-platform-login` tool and then re-running this command to verify. This login is required to e.g. create and manage Prisma Postgres databases.",
-        "userDescription": "Provides information about the currently logged in user on the Prisma Platform to use e.g. Prisma Postgres.",
-        "canBeReferencedInPrompt": true,
-        "icon": "./prisma_icon.svg",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "projectCwd": {
-              "type": "string",
-              "description": "The current working directory of the user's project. This should be the top level directory of the project but in a monorepo setup could also be a specific package or app directory."
-            }
-          }
-        }
-      },
-      {
         "name": "prisma-platform-login",
         "tags": [
           "prisma",
@@ -407,16 +383,7 @@
         "modelDescription": "Login or create an account in order to be able to use Prisma Postgres.",
         "userDescription": "Login or create an account in order to be able to use Prisma Postgres.",
         "canBeReferencedInPrompt": true,
-        "icon": "./prisma_icon.svg",
-        "inputSchema": {
-          "type": "object",
-          "properties": {
-            "projectCwd": {
-              "type": "string",
-              "description": "The current working directory of the user's project. This should be the top level directory of the project but in a monorepo setup could also be a specific package or app directory."
-            }
-          }
-        }
+        "icon": "./prisma_icon.svg"
       },
       {
         "name": "prisma-postgres-create-database",
@@ -428,26 +395,29 @@
         ],
         "toolReferenceName": "prisma-postgres-create-database",
         "displayName": "Prisma Postgres Create Database",
-        "modelDescription": "Create a new online Prisma Postgres database.\nSpecify a name that makes sense to the user - maybe the name of the project they are working on.\nSpecify a region that makes sense for the user. Pick between these three options: us-east-1, eu-west-3, ap-northeast-1. If you are unsure, pick us-east-1.\nProvide the current working directory of the users project. This should be the top level directory of the project.\nIf the response indicates that you have reached the workspace plan limit, you should instruct the user to do one of these things:\nIf they want to connect to an existing database, they should go to console.prisma.io and copy the connection string\nIf they want to upgrade their plan, they should go to console.prisma.io and upgrade their plan in order to be able to create more databases\nIf they want to delete a database they no longer need, they should go to console.prisma.io and delete the database project.\nIf the user is not logged in, you should suggest them to login via the `prisma-platform-login` tool.",
+        "modelDescription": "Create a new online Prisma Postgres database.\nSpecify a name that makes sense to the user - maybe the name of the project they are working on.\nSpecify a region that makes sense for the user. Pick between these options: us-east-1, eu-west-3, ap-northeast-1, ap-southeast-1 or call the tool without a region to get an up-to-date list of available regions. If you are unsure, pick us-east-1.\n\nIf the response indicates that you have reached the workspace plan limit, you should instruct the user to do one of these things:\nIf they want to connect to an existing database, they should go to console.prisma.io and copy the connection string\nIf they want to upgrade their plan, they should go to console.prisma.io and upgrade their plan in order to be able to create more databases\nIf they want to delete a database they no longer need, they should go to console.prisma.io and delete the database project.\nIf the user is not logged in, you should suggest them to login via the `prisma-platform-login` tool.",
         "userDescription": "Create a new online Prisma Postgres database.",
         "canBeReferencedInPrompt": true,
         "icon": "./prisma_icon.svg",
         "inputSchema": {
           "type": "object",
           "properties": {
-            "projectCwd": {
+            "workspaceId": {
               "type": "string",
-              "description": "The current working directory of the user's project. This should be the top level directory of the project but in a monorepo setup could also be a specific package or app directory."
+              "description": "The id of workspace in which the new database shall be created. You can leave this blank if you don't have a prisma workspace id. The tool will prompt you provide you with a list of workspaces should the user have multiple workspaces."
             },
             "name": {
               "type": "string",
               "description": "The name for the new database."
             },
-            "region": {
+            "regionId": {
               "type": "string",
-              "description": "The region for the new database. Pick between these three options: us-east-1, eu-west-3, ap-northeast-1"
+              "description": "The region for the new database. If you do not specify a region the tool will return a list of available regions and prompt you to specify one of them."
             }
-          }
+          },
+          "required": [
+            "name"
+          ]
         }
       }
     ],
@@ -493,6 +463,10 @@
         },
         {
           "command": "prisma.studio.launchForDatabase",
+          "when": "false"
+        },
+        {
+          "command": "prisma.studio.getRemoteDatabaseConnectionString",
           "when": "false"
         }
       ],

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -191,19 +191,19 @@
       },
       {
         "command": "prisma.refresh",
-        "title": "Refresh Prisma Postgres List",
+        "title": "Refresh Database List",
         "icon": "$(refresh)",
         "category": "Prisma"
       },
       {
         "command": "prisma.login",
-        "title": "Login to Prisma Platform Workspace",
+        "title": "Login to Workspace",
         "icon": "$(sign-in)",
         "category": "Prisma"
       },
       {
         "command": "prisma.logout",
-        "title": "Logout from Prisma Platform Workspace",
+        "title": "Logout from Workspace",
         "icon": "$(sign-out)",
         "category": "Prisma"
       },
@@ -215,7 +215,7 @@
       },
       {
         "command": "prisma.deleteProject",
-        "title": "Delete Prisma Postgres Project",
+        "title": "Delete Project",
         "icon": "$(trash)",
         "category": "Prisma"
       },
@@ -239,13 +239,13 @@
       },
       {
         "command": "prisma.openRemoteDatabaseInPrismaConsole",
-        "title": "Open Remote Prisma Postgres Database in Prisma Console",
+        "title": "Open in Prisma Console",
         "icon": "$(link-external)",
         "category": "Prisma"
       },
       {
         "command": "prisma.deleteRemoteDatabase",
-        "title": "Delete Remote Prisma Postgres Database",
+        "title": "Delete Database",
         "icon": "$(trash)",
         "category": "Prisma"
       },

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/createProjectInclDatabase.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/createProjectInclDatabase.ts
@@ -27,7 +27,7 @@ export const createProjectInclDatabase = async (ppgRepository: PrismaPostgresRep
   const result = await window.withProgress(
     {
       location: ProgressLocation.Notification,
-      title: `Creating project with database in ${region.name}...`,
+      title: `Creating project with database...`,
     },
     () => ppgRepository.createProject({ workspaceId, name, region: region.id }),
   )
@@ -38,7 +38,7 @@ export const createProjectInclDatabase = async (ppgRepository: PrismaPostgresRep
       type: 'databaseCreated',
     })
   } else {
-    void window.showInformationMessage(`Project ${name} created`)
+    void window.showInformationMessage(`Project created`)
   }
 
   return result

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/createRemoteDatabase.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/createRemoteDatabase.ts
@@ -88,7 +88,7 @@ export const createRemoteDatabase = async (ppgRepository: PrismaPostgresReposito
   const result = await window.withProgress(
     {
       location: ProgressLocation.Notification,
-      title: `Creating remote database in ${region.name}...`,
+      title: `Creating remote database...`,
     },
     () => ppgRepository.createRemoteDatabase({ workspaceId, projectId, name, region: region.id }),
   )

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/deleteProject.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/deleteProject.ts
@@ -17,10 +17,10 @@ export const deleteProject = async (ppgRepository: PrismaPostgresRepository, arg
   await window.withProgress(
     {
       location: ProgressLocation.Notification,
-      title: `Deleting project '${args.name}'...`,
+      title: `Deleting project...`,
     },
     () => ppgRepository.deleteProject({ workspaceId: args.workspaceId, id: args.id }),
   )
 
-  void window.showInformationMessage(`Project '${args.name}' deleted`)
+  void window.showInformationMessage(`Project deleted`)
 }

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/deleteRemoteDatabase.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/deleteRemoteDatabase.ts
@@ -17,7 +17,7 @@ export const deleteRemoteDatabase = async (ppgRepository: PrismaPostgresReposito
   await window.withProgress(
     {
       location: ProgressLocation.Notification,
-      title: `Deleting database '${args.name}'...`,
+      title: `Deleting database...`,
     },
     () =>
       ppgRepository.deleteRemoteDatabase({
@@ -27,5 +27,5 @@ export const deleteRemoteDatabase = async (ppgRepository: PrismaPostgresReposito
       }),
   )
 
-  void window.showInformationMessage(`Database '${args.name}' deleted`)
+  void window.showInformationMessage(`Database deleted`)
 }

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/getRemoteDatabaseConnectionString.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/getRemoteDatabaseConnectionString.ts
@@ -34,7 +34,7 @@ export const getRemoteDatabaseConnectionString = async (ppgRepository: PrismaPos
   const createdConnectionString = await window.withProgress(
     {
       location: ProgressLocation.Notification,
-      title: `Creating connection string for database '${args.name}'...`,
+      title: `Creating connection string...`,
     },
     () =>
       ppgRepository.createRemoteDatabaseConnectionString({

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/launchStudio.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/launchStudio.ts
@@ -59,7 +59,7 @@ const getConnectionString = async (ppgRepository: PrismaPostgresRepository, data
   const createdConnectionString = await window.withProgress(
     {
       location: ProgressLocation.Notification,
-      title: `Creating connection string for database...`,
+      title: `Creating connection string...`,
     },
     () => ppgRepository.createRemoteDatabaseConnectionString(database),
   )

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/login.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/login.ts
@@ -37,9 +37,9 @@ export const handleAuthCallback = async ({
       },
       () => ppgRepository.addWorkspace({ token: result.token, refreshToken: result.refreshToken }),
     )
-    void window.showInformationMessage('Login to Prisma successful!')
+    void window.showInformationMessage('Workspace connected!')
   } catch (error) {
     console.error(error)
-    void window.showErrorMessage('Login to Prisma failed! Please try again.')
+    void window.showErrorMessage('Login to Workspace failed! Please try again.')
   }
 }

--- a/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/index.ts
@@ -59,9 +59,7 @@ export default {
         await handleCommandError('Create Remote Database', () => createRemoteDatabase(ppgRepository, args))
       }),
       commands.registerCommand('prisma.getRemoteDatabaseConnectionString', async (args: unknown) => {
-        await handleCommandError('Get Remote Database Connection String', () =>
-          getRemoteDatabaseConnectionString(ppgRepository, args),
-        )
+        await handleCommandError('Get Connection String', () => getRemoteDatabaseConnectionString(ppgRepository, args))
       }),
       commands.registerCommand('prisma.openRemoteDatabaseInPrismaConsole', async (args: unknown) => {
         if (isRemoteDatabase(args)) {
@@ -76,7 +74,7 @@ export default {
         await handleCommandError('Delete Remote Database', () => deleteRemoteDatabase(ppgRepository, args))
       }),
       commands.registerCommand('prisma.studio.launchForDatabase', async (args: unknown) => {
-        await handleCommandError('Launch Studio for Database', () => launchStudio({ ppgRepository, args, context }))
+        await handleCommandError('Launch Studio', () => launchStudio({ ppgRepository, args, context }))
       }),
     )
   },

--- a/packages/vscode/src/plugins/prisma-postgres-manager/shared-ui/handleCommandError.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/shared-ui/handleCommandError.ts
@@ -11,11 +11,11 @@ export const handleCommandError = async <T>(cmdTitle: string, cmd: () => Promise
     return await cmd()
   } catch (error) {
     if (error instanceof CommandAbortError) {
-      void window.showInformationMessage(`${cmdTitle} aborted:\n${error.message}`)
+      void window.showInformationMessage(`${cmdTitle} aborted: ${error.message}`)
     } else if (error instanceof Error) {
-      void window.showErrorMessage(`${cmdTitle} failed:\n${error.message}`)
+      void window.showErrorMessage(`${cmdTitle} failed: ${error.message}`)
     } else {
-      void window.showErrorMessage(`${cmdTitle}:\nAn unknown error occurred`)
+      void window.showErrorMessage(`${cmdTitle} failed: An unknown error occurred`)
     }
     return null
   }


### PR DESCRIPTION
This PR streamlines various messages and fixes issues with getting the correct error message out of API errors.

Principles I tried to follow:
- Use short messages and names (e.g. `Delete Project` instead of `Delete Prisma Postgres Project`)
- Command failures name the command that failed. (e.g. `Delete Remote Database failed: You are not allowed to delete the default environment.`)
- Do not include additional names, regions etc info in success messages to keep them short and simple