### PR TITLE
feat(autocomplete): ORM-1045 shardKey attribute autocomplete

### DIFF
--- a/packages/language-server/src/__test__/completions/single-file.test.ts
+++ b/packages/language-server/src/__test__/completions/single-file.test.ts
@@ -628,6 +628,10 @@ describe('Completions', function () {
       label: '@@schema',
       kind: CompletionItemKind.Property,
     }
+    const blockAttributeShardKey = {
+      label: '@@shardKey',
+      kind: CompletionItemKind.Property,
+    }
     const typeProperty = {
       label: 'type',
       kind: CompletionItemKind.Property,
@@ -817,6 +821,53 @@ describe('Completions', function () {
               ],
             },
           })
+        })
+      })
+    })
+
+    describe('shardKey', () => {
+      test('MySQL', () => {
+        assertCompletion({
+          provider: 'mysql',
+          previewFeatures: ['shardKeys'],
+          schema: /* Prisma */ `
+          model Shard {
+            id      Int    @id
+            |
+          }          
+          `,
+          expected: {
+            isIncomplete: false,
+            items: [
+              blockAttributeMap,
+              blockAttributeUnique,
+              blockAttributeIndex,
+              blockAttributeIgnore,
+              blockAttributeShardKey,
+            ],
+          },
+        })
+      })
+      test('PostgreSQL', () => {
+        assertCompletion({
+          provider: 'postgresql',
+          previewFeatures: ['shardKeys'],
+          schema: /* Prisma */ `
+            model A {
+              id    Int @id
+              |
+            }
+          `,
+          expected: {
+            isIncomplete: false,
+            items: [
+              blockAttributeMap,
+              blockAttributeUnique,
+              blockAttributeIndex,
+              blockAttributeIgnore,
+              // blockAttributeShardKey,
+            ],
+          },
         })
       })
     })
@@ -2178,6 +2229,10 @@ describe('Completions', function () {
       label: '@db',
       kind: CompletionItemKind.Property,
     }
+    const fieldAttributeShardKey = {
+      label: '@shardKey',
+      kind: CompletionItemKind.Property,
+    }
 
     const functionCuid = {
       label: 'cuid()',
@@ -2421,6 +2476,55 @@ describe('Completions', function () {
           isIncomplete: false,
           items: [fieldAttributeUnique, fieldAttributeDefault, fieldAttributeRelation, fieldAttributeIgnore],
         },
+      })
+    })
+
+    describe('@shardKey', () => {
+      test('MySQL', () => {
+        assertCompletion({
+          provider: 'mysql',
+          previewFeatures: ['shardKeys'],
+          schema: /* Prisma */ `
+          model Post {
+            id Int @id @default()
+            name String |
+          }`,
+          expected: {
+            isIncomplete: false,
+            items: [
+              fieldAttributeDatasourceName,
+              fieldAttributeUnique,
+              fieldAttributeMap,
+              fieldAttributeDefault,
+              fieldAttributeRelation,
+              fieldAttributeIgnore,
+              fieldAttributeShardKey,
+            ],
+          },
+        })
+      })
+      test('PostgreSQL', () => {
+        assertCompletion({
+          provider: 'postgresql',
+          previewFeatures: ['shardKeys'],
+          schema: /* Prisma */ `
+          model Post {
+            id Int @id @default()
+            name String |
+          }`,
+          expected: {
+            isIncomplete: false,
+            items: [
+              fieldAttributeDatasourceName,
+              fieldAttributeUnique,
+              fieldAttributeMap,
+              fieldAttributeDefault,
+              fieldAttributeRelation,
+              fieldAttributeIgnore,
+              // fieldAttributeShardKey
+            ],
+          },
+        })
       })
     })
 

--- a/packages/language-server/src/lib/completions/completions.json
+++ b/packages/language-server/src/lib/completions/completions.json
@@ -215,6 +215,13 @@
       "documentation": "Designate which schema this belongs to. [Learn more](https://pris.ly/d/multi-schema-configuration)",
       "fullSignature": "@@schema(_: String)",
       "params": []
+    },
+    {
+      "label": "@@shardKey",
+      "insertText": "@@shardKey($0)",
+      "documentation": "Defines a shard key based on multiple fields of the model. Only compatible with Planetscale.",
+      "fullSignature": "@@shardKey(_: FieldReference[])",
+      "params": []
     }
   ],
   "fieldAttributes": [
@@ -328,6 +335,12 @@
       "label": "@ignore",
       "fullSignature": "@ignore",
       "documentation": "A field with an `@ignore` attribute can be kept in sync with the database schema using Prisma Migrate and Introspection, but won't be exposed in Prisma Client.",
+      "params": []
+    },
+    {
+      "label": "@shardKey",
+      "fullSignature": "@shardKey",
+      "documentation": "Defines the field as the shard key for the model. Only compatible with Planetscale.",
       "params": []
     }
   ],

--- a/packages/language-server/src/lib/types.ts
+++ b/packages/language-server/src/lib/types.ts
@@ -8,7 +8,11 @@ export type BlockType = ConfigBlockType | DatamodelBlockType
 
 export type PreviewFeatures =
   // value must be lowercase
-  Lowercase<'fullTextIndex'> | Lowercase<'postgresqlExtensions'> | Lowercase<'multiSchema'> | Lowercase<'views'>
+  | Lowercase<'fullTextIndex'>
+  | Lowercase<'postgresqlExtensions'>
+  | Lowercase<'multiSchema'>
+  | Lowercase<'views'>
+  | Lowercase<'shardKeys'>
 
 export interface LSOptions {
   /**


### PR DESCRIPTION
Adding `@@shardKey` and `@shardKey` attributes to the autocomplete of the language server. Only active if provider is mysql and the preview feature `shardKeys` is active.