### PR TITLE
chore: remove messages published to slack that are no longer needed

### DIFF
--- a/.github/workflows/1_2_b_bump_extension_only.yml
+++ b/.github/workflows/1_2_b_bump_extension_only.yml
@@ -71,20 +71,3 @@ jobs:
           workflow: 3. Test Language Server and publish
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "npm_channel": "patch-dev", "extension_version": "${{ steps.update.outputs.next_extension_version }}", "branch": "${{ github.ref_name }}", "trigger_reason": "Commit from ${{ github.ref_name }}" }'
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ failure() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: "1/2b. - Bumping versions for 'extension only' failed :x:"
-          SLACK_COLOR: '#FF0000'
-          SLACK_MESSAGE: '${{ steps.update.outputs.next_extension_version  }} - On push to ${{ github.ref_name }}.'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/1_2_c_promote_patch_to_stable.yml
+++ b/.github/workflows/1_2_c_promote_patch_to_stable.yml
@@ -56,20 +56,3 @@ jobs:
           workflow: 3. Test Language Server and publish
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "npm_channel": "latest", "extension_version": "${{ steps.update.outputs.next_extension_version }}", "branch": "stable", "trigger_reason": "Manual trigger promoting patch branch to stable" }'
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ failure() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '1/2c. - Promoting patch branch to stable failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_MESSAGE: '${{ steps.update.outputs.next_extension_version  }} - On manual trigger promoting patch branch to stable.'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/1_check_for_updates.yml
+++ b/.github/workflows/1_check_for_updates.yml
@@ -53,19 +53,3 @@ jobs:
           workflow: 2. Bump versions
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "npm_channel": "patch-dev", "version": "${{ steps.check_update.outputs.patch-dev_version }}" }'
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ failure() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '1. Checking for Prisma CLI Update failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/2_bump_versions.yml
+++ b/.github/workflows/2_bump_versions.yml
@@ -82,20 +82,3 @@ jobs:
           workflow: 3. Test Language Server and publish
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "npm_channel": "${{ github.event.inputs.npm_channel }}", "extension_version": "${{ steps.update.outputs.next_extension_version }}", "branch": "${{steps.setup_branch.outputs.branch}}", "trigger_reason": "Prisma CLI version ${{github.event.inputs.version}}" }'
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ failure() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '2. Bumping versions failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_MESSAGE: '${{github.event.inputs.version}} - On new Prisma CLI version ${{github.event.inputs.version}}'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/3_LS_tests_publish.yml
+++ b/.github/workflows/3_LS_tests_publish.yml
@@ -82,29 +82,3 @@ jobs:
           workflow: 4. Bump LS in VSCode extension
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "npm_channel": "${{ github.event.inputs.npm_channel }}", "extension_version": "${{ github.event.inputs.extension_version }}", "branch": "${{ github.event.inputs.branch }}", "trigger_reason": "${{github.event.inputs.trigger_reason}}" }'
-
-  slack:
-    name: Send slack notification
-    runs-on: ubuntu-latest
-    timeout-minutes: 7
-    needs: [tests, bump]
-    if: always()
-    env:
-      SLACK_MESSAGE: '${{ needs.build.outputs.tag_name }} - ${{github.event.inputs.trigger_reason}} '
-    steps:
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ always() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() || needs.tests.result == 'failure' || needs.bump.result == 'failure' }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '3. Test Language Server and publish failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_MESSAGE: '${{github.event.inputs.extension_version}} - ${{github.event.inputs.trigger_reason}} '
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/4_bump_LS_in_extension.yml
+++ b/.github/workflows/4_bump_LS_in_extension.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           PACKAGE_JSON_PATH="./packages/language-server/package.json"
           echo $PACKAGE_JSON_PATH
-          ENGINES_VERSION=$(jq -r '.prisma.enginesVersion' ${PACKAGE_JSON_PATH}) 
+          ENGINES_VERSION=$(jq -r '.prisma.enginesVersion' ${PACKAGE_JSON_PATH})
           echo "engines=$ENGINES_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push to branch
@@ -70,20 +70,3 @@ jobs:
           workflow: 5. Integration tests in VSCode folder with published LS
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "npm_channel": "${{ github.event.inputs.npm_channel }}", "extension_version": "${{ github.event.inputs.extension_version }}", "branch": "${{ github.event.inputs.branch }}", "trigger_reason": "${{github.event.inputs.trigger_reason}}" }'
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ failure() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '4. Bumping LS in VSCode extension failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_MESSAGE: '${{github.event.inputs.extension_version}} - ${{github.event.inputs.trigger_reason}} '
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/5_e2e_tests.yml
+++ b/.github/workflows/5_e2e_tests.yml
@@ -70,20 +70,3 @@ jobs:
           workflow: 6. Build extension
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "npm_channel": "${{ github.event.inputs.npm_channel }}", "extension_version": "${{ github.event.inputs.extension_version }}", "branch": "${{github.event.inputs.branch}}", "trigger_reason": "${{github.event.inputs.trigger_reason}}" }'
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ always() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() || needs.tests.result == 'failure' }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '5. Integration tests in VSCode folder with published LS failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_MESSAGE: '${{github.event.inputs.extension_version}} - ${{github.event.inputs.trigger_reason}} '
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/6_build.yml
+++ b/.github/workflows/6_build.yml
@@ -20,9 +20,6 @@ on:
 env:
   ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
   PRISMA_TELEMETRY_INFORMATION: 'language-tools 6_build.yml'
-  SLACK_USERNAME: Prismo
-  SLACK_ICON_EMOJI: ':ship:'
-  SLACK_MSG_AUTHOR: prisma-bot
 
 jobs:
   build:
@@ -96,38 +93,3 @@ jobs:
           workflow: 7. Publish
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "asset_name": "${{ steps.get_asset_name.outputs.asset_name }}", "tag_name": "${{ steps.names.outputs.tag_name }}", "trigger_reason": "${{github.event.inputs.trigger_reason}}" }'
-
-  slack:
-    name: Send slack notification
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: [build]
-    if: always()
-    env:
-      SLACK_MESSAGE: '${{ needs.build.outputs.tag_name }} - ${{github.event.inputs.trigger_reason}} '
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ always() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() || needs.build.result == 'failure' }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '6. Release failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-
-      - name: Slack Notification on Success
-        if: ${{ success() && needs.build.result == 'success' }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '6. Release was successful :white_check_mark:'
-          SLACK_COLOR: '#008000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: feed-language-tools

--- a/.github/workflows/7_publish.yml
+++ b/.github/workflows/7_publish.yml
@@ -17,17 +17,12 @@ on:
 env:
   ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
   PRISMA_TELEMETRY_INFORMATION: 'language-tools 7_publish.yml'
-  SLACK_USERNAME: Prismo
-  SLACK_ICON_EMOJI: ':ship:'
-  SLACK_MSG_AUTHOR: prisma-bot
 
 jobs:
   marketplace:
     name: Publish to marketplace
     runs-on: ubuntu-latest
     timeout-minutes: 7
-    env:
-      SLACK_MESSAGE: '${{ github.event.inputs.tag_name }} - ${{github.event.inputs.trigger_reason}}'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,34 +51,10 @@ jobs:
       - name: publish vsix to marketplace
         run: cd packages/vscode && npx vsce publish --pat ${{ secrets.AZURE_DEVOPS_PERSONAL_ACCESS_TOKEN}} --packagePath ${{github.workspace}}/${{ github.event.inputs.asset_name }}
 
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ always() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '7. Publishing to marketplace failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-
-      - name: Slack Notification on Success
-        if: ${{ success() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '7. Published to marketplace :white_check_mark:'
-          SLACK_COLOR: '#008000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: feed-language-tools
-
   open-vsx:
     name: Publish to open-vsx
     runs-on: ubuntu-latest
     timeout-minutes: 7
-    env:
-      SLACK_MESSAGE: '${{ github.event.inputs.tag_name }} - ${{github.event.inputs.trigger_reason}}'
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js
@@ -107,25 +78,3 @@ jobs:
 
       - name: Publish vsix to open-vsx.org
         run: cd packages/vscode && npx ovsx --debug publish ${{github.workspace}}/${{ github.event.inputs.asset_name }} --pat  ${{ secrets.OPEN_VSX_ACCESS_TOKEN }}
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ always() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '7. Publishing to open-vsx failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-
-      - name: Slack Notification on Success
-        if: ${{ success() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: '7. Published to open-vsx :white_check_mark:'
-          SLACK_COLOR: '#008000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: feed-language-tools

--- a/.github/workflows/PR_build_extension.yml
+++ b/.github/workflows/PR_build_extension.yml
@@ -13,9 +13,6 @@ on:
 env:
   ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
   PRISMA_TELEMETRY_INFORMATION: 'language-tools PR_build_extension.yml'
-  SLACK_USERNAME: Prismo
-  SLACK_ICON_EMOJI: ':ship:'
-  SLACK_MSG_AUTHOR: prisma-bot
 
 jobs:
   build:
@@ -63,26 +60,3 @@ jobs:
         with:
           name: pr-artifact
           path: ./packages/vscode/*.vsix
-
-  slack:
-    name: Send slack notification
-    runs-on: ubuntu-latest
-    needs: [build]
-    if: always() && github.repository == 'prisma/language-tools'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ always() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() || needs.build.result == 'failure' }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: 'PR Build extension failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures

--- a/.github/workflows/e2e_check_for_new_published_vsix.yml
+++ b/.github/workflows/e2e_check_for_new_published_vsix.yml
@@ -42,19 +42,3 @@ jobs:
           workflow: E2E tests after release on VSIX
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "extension_type": "stable", "extension_version": "${{ steps.check_published_version.outputs.new_stable_version }}" }'
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ failure() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: 'Check for new release on Marketplace failed :x:'
-          SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-          SLACK_USERNAME: Prismo
-          SLACK_ICON_EMOJI: ':boom:'
-          SLACK_MSG_AUTHOR: prisma-bot

--- a/.github/workflows/e2e_published_vsix.yml
+++ b/.github/workflows/e2e_published_vsix.yml
@@ -12,10 +12,7 @@ on:
         required: true
 
 env:
-  SLACK-USERNAME: Prismo
-  SLACK_ICON_EMOJI: ':robot_face:'
   ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
-  SLACK_MSG_AUTHOR: prisma-bot
   # * Enables github logging
   # ACTIONS_STEP_DEBUG: true
 
@@ -67,27 +64,3 @@ jobs:
         run: npm run test:bump ${{ github.event.inputs.extension_type }} ${{ github.event.inputs.extension_version }}
         env:
           GH_TOKEN: ${{ secrets.PRISMA_BOT_TOKEN }} # Needed and used in the shell script behind test:bump
-
-      - name: 'Set current job url in SLACK_FOOTER env var'
-        if: ${{ always() }}
-        run: echo "SLACK_FOOTER=<$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|Click here to go to the job logs>" >> $GITHUB_ENV
-
-      - name: Slack Notification on Failure
-        if: ${{ needs.test.result == 'failure' && needs.test.outputs.installed-extension }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: 'Testing released ${{ github.event.inputs.extension_type }} extension failed :x:'
-          SLACK_MESSAGE: ${{ github.event.inputs.extension_version }}
-          SLACK_COLOR: '#FF0000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_FAILURES }}
-          SLACK_CHANNEL: feed-language-tools-failures
-
-      - name: Slack Notification on Success
-        if: ${{ needs.test.result == 'success' && needs.test.outputs.installed-extension }}
-        uses: rtCamp/action-slack-notify@v2.3.2
-        env:
-          SLACK_TITLE: 'Tested released ${{ github.event.inputs.extension_type }} extension :white_check_mark:'
-          SLACK_MESSAGE: ${{ github.event.inputs.extension_version }}
-          SLACK_COLOR: '#008000'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: feed-vscode-e2e-tests


### PR DESCRIPTION
I think there is no utility in any of those notifications anymore.
For dev releases we can keep track of them with the action status check, while for regular releases we can just monitor the pipeline ourselves.

Related: https://github.com/prisma/action-status-check/pull/3