### PR TITLE
fix: telemetry product names.

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -40,6 +40,7 @@
         "mocha": "10.8.2",
         "openapi-typescript": "7.8.0",
         "ovsx": "0.10.1",
+        "pkg-types": "2.2.0",
         "typescript": "5.7.3"
       },
       "engines": {
@@ -1654,6 +1655,13 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "node_modules/confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -2012,6 +2020,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4026,6 +4041,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
+      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/playwright": {
@@ -6731,6 +6758,12 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "confbox": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
+      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "dev": true
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -6995,6 +7028,12 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "dev": true,
       "optional": true
+    },
+    "exsolve": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -8484,6 +8523,17 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "pkg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.2.0.tgz",
+      "integrity": "sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==",
+      "dev": true,
+      "requires": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
     },
     "playwright": {
       "version": "1.53.1",

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -652,6 +652,7 @@
     "mocha": "10.8.2",
     "openapi-typescript": "7.8.0",
     "ovsx": "0.10.1",
+    "pkg-types": "2.2.0",
     "typescript": "5.7.3"
   },
   "gitHead": "7d51b157647fe1705813a30d1a77b8ccf136b8d4",

--- a/packages/vscode/src/getPackageJSON.ts
+++ b/packages/vscode/src/getPackageJSON.ts
@@ -1,0 +1,6 @@
+import type { ExtensionContext } from 'vscode'
+
+// @ts-expect-error don't worry about the type.
+export function getPackageJSON(context: ExtensionContext): import('pkg-types').PackageJson {
+  return context.extension.packageJSON as never
+}

--- a/packages/vscode/src/plugins/prisma-postgres-manager/commands/deployLocalDatabase.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/commands/deployLocalDatabase.ts
@@ -3,6 +3,7 @@ import TelemetryReporter from '../../../telemetryReporter'
 import { LocalDatabaseSchema, PrismaPostgresRepository } from '../PrismaPostgresRepository'
 import { createRemoteDatabaseSafely } from './createRemoteDatabase'
 import { type ExtensionContext, ProgressLocation, window } from 'vscode'
+import { getPackageJSON } from '../../../getPackageJSON'
 
 export interface DeployLocalDatabaseOptions {
   args: unknown
@@ -13,9 +14,11 @@ export interface DeployLocalDatabaseOptions {
 export async function deployLocalDatabase(options: DeployLocalDatabaseOptions): Promise<void> {
   const { args, context, ppgRepository } = options
 
+  const packageJson = getPackageJSON(context)
+
   const telemetryReporter = new TelemetryReporter(
-    `prisma.${context.extension.id}.dev`,
-    (context.extension.packageJSON as { version: string }).version,
+    `prisma.${packageJson.name || 'prisma-unknown'}.dev`,
+    packageJson.version || '0.0.0',
   )
 
   try {

--- a/packages/vscode/src/plugins/prisma-studio/commands/launch/openNewStudioTab.ts
+++ b/packages/vscode/src/plugins/prisma-studio/commands/launch/openNewStudioTab.ts
@@ -3,6 +3,7 @@ import { getStudioPageHtml } from './getStudioPageHtml'
 import { startStudioServer } from './startStudioServer'
 import TelemetryReporter from '../../../../telemetryReporter'
 import type { LaunchArg } from '../../../prisma-postgres-manager/commands/launchStudio'
+import { getPackageJSON } from '../../../../getPackageJSON'
 
 export interface OpenNewStudioTabArgs {
   context: ExtensionContext
@@ -16,11 +17,12 @@ export interface OpenNewStudioTabArgs {
  */
 export async function openNewStudioTab(args: OpenNewStudioTabArgs) {
   const { context } = args
-  const { extension } = context
+
+  const packageJSON = getPackageJSON(context)
 
   const telemetryReporter = new TelemetryReporter(
-    `prisma.${extension.id}.studio`,
-    (extension.packageJSON as { version: string }).version,
+    `prisma.${packageJSON.name || 'prisma-unknown'}.studio`,
+    (packageJSON as { version: string }).version || '0.0.0',
   )
 
   const { server, url } = await startStudioServer({ ...args, telemetryReporter })

--- a/packages/vscode/src/plugins/prisma-studio/commands/launch/startStudioServer.ts
+++ b/packages/vscode/src/plugins/prisma-studio/commands/launch/startStudioServer.ts
@@ -11,6 +11,7 @@ import type { Query } from '@prisma/studio-core-licensed/data'
 import type { StudioProps } from '@prisma/studio-core-licensed/ui'
 import type TelemetryReporter from '../../../../telemetryReporter'
 import type { LaunchArg } from '../../../prisma-postgres-manager/commands/launchStudio'
+import { isDebugOrTestSession } from '../../../../util'
 
 export interface StartStudioServerArgs {
   context: ExtensionContext
@@ -85,7 +86,7 @@ export async function startStudioServer(args: StartStudioServerArgs) {
     const { eventId, name, payload, timestamp } =
       await ctx.req.json<Parameters<NonNullable<StudioProps['onEvent']>>[0]>()
 
-    if (name !== 'studio_launched') {
+    if (isDebugOrTestSession() || name !== 'studio_launched') {
       return ctx.body(null, 204)
     }
 


### PR DESCRIPTION
Hey 👋 

closes EXP-1687
closes EXP-1456

`product` names were off in telemetry events for `dev` and `studio`.