### PR TITLE
feat: add ESM generator completions

### DIFF
--- a/packages/language-server/src/__test__/completions/single-file.test.ts
+++ b/packages/language-server/src/__test__/completions/single-file.test.ts
@@ -514,6 +514,10 @@ describe('Completions', function () {
       label: 'engineType',
       kind: CompletionItemKind.Field,
     }
+    const moduleFormat = {
+      label: 'moduleFormat',
+      kind: CompletionItemKind.Field,
+    }
     //#endregion
 
     test('Diagnoses generator field suggestions in empty block', () => {
@@ -524,7 +528,7 @@ describe('Completions', function () {
         }`,
         expected: {
           isIncomplete: false,
-          items: [fieldProvider, fieldPreviewFeatures, fieldOutput, fieldEngineType, fieldBinaryTargets],
+          items: [fieldProvider, fieldPreviewFeatures, fieldOutput, fieldEngineType, fieldBinaryTargets, moduleFormat],
         },
       })
     })
@@ -538,7 +542,7 @@ describe('Completions', function () {
           }`,
         expected: {
           isIncomplete: false,
-          items: [fieldPreviewFeatures, fieldOutput, fieldEngineType, fieldBinaryTargets],
+          items: [fieldPreviewFeatures, fieldOutput, fieldEngineType, fieldBinaryTargets, moduleFormat],
         },
       })
       assertCompletion({
@@ -549,7 +553,7 @@ describe('Completions', function () {
           }`,
         expected: {
           isIncomplete: false,
-          items: [fieldProvider, fieldPreviewFeatures, fieldEngineType, fieldBinaryTargets],
+          items: [fieldProvider, fieldPreviewFeatures, fieldEngineType, fieldBinaryTargets, moduleFormat],
         },
       })
     })

--- a/packages/language-server/src/lib/completions/completions.json
+++ b/packages/language-server/src/lib/completions/completions.json
@@ -105,6 +105,11 @@
       "insertText": "binaryTargets = \"$0\"",
       "documentation": "Specifies the OS on which the Prisma Client will run to ensure compatibility of the query engine. [Learn more](https://pris.ly/d/generator-fields).",
       "fullSignature": "binaryTargets = BinaryTargets[] | env(\"ENVIRONMENT_VARIABLE\")"
+    },
+    {
+      "label": "moduleFormat",
+      "insertText": "moduleFormat = \"$0\"",
+      "documentation": "Defines the module format for the generated Prisma Client. Can be 'cjs' or 'esm'."
     }
   ],
   "blockAttributes": [
@@ -399,6 +404,10 @@
     {
       "label": "prisma-client-js",
       "documentation": "Built-in generator."
+    },
+    {
+      "label": "prisma-client",
+      "documentation": "Built-in generator with ESM support. Generates the Prisma Client into a custom directory. Currently in early access."
     }
   ],
   "generatorProviderArguments": [


### PR DESCRIPTION
It'd be nice to have separate completions for each generator, but it seems like it'd require refactoring, so just followed what it does (showing one list of options regardless of what the generator is)