### PR TITLE
fix: prisma dev instances never running, studio not launching.

### DIFF
--- a/packages/vscode/src/plugins/prisma-postgres-manager/PrismaDevRepository.ts
+++ b/packages/vscode/src/plugins/prisma-postgres-manager/PrismaDevRepository.ts
@@ -159,7 +159,7 @@ export class PrismaDevRepository {
 
     const { isServerRunning, ServerState } = await import('@prisma/dev/internal/state')
 
-    const states = await ServerState.scan({ debug: true, onlyMetadata: true })
+    const states = await ServerState.scan({ debug: true })
 
     const instances = states.map((state) => ({
       id: state.name,


### PR DESCRIPTION
Hey :wave:

This one was spotted in the demo. Accidentally merged with `onlyMetadata`.