### PR TITLE
fix tests following formatting/codegen changes in `prisma-engines`.

### DIFF
--- a/packages/vscode/fixtures/format/expected.snapshot
+++ b/packages/vscode/fixtures/format/expected.snapshot
@@ -26,6 +26,6 @@ model User {
 model PostTitle {
   id     Int    @id @default(autoincrement())
   title  String
-  Post   Post?  @relation(fields: [postId], references: [id])
+  post   Post?  @relation(fields: [postId], references: [id])
   postId Int?
 }


### PR DESCRIPTION
Hey 👋 

closes https://linear.app/prisma-company/issue/PTL-472/fix-vs-code-extension-tests-following-my-formattingcode-actions-prisma.

Tests are broken following the changes in https://github.com/prisma/prisma-engines/pull/5656.

This PR fixes them.