### PR TITLE
chore: use prisma 6 language server hotfix

### DIFF
--- a/packages/vscode/package-lock.json
+++ b/packages/vscode/package-lock.json
@@ -24,7 +24,7 @@
         "hono": "4.7.10",
         "minimatch": "6.2.0",
         "openapi-fetch": "0.14.0",
-        "prisma-6-language-server": "npm:@prisma/language-server@6.19.0",
+        "prisma-6-language-server": "npm:@prisma/language-server@6.19.0-hotfix.1",
         "vscode-languageclient": "7.0.0",
         "watcher": "1.2.0",
         "zod": "3.24.3"
@@ -4355,14 +4355,14 @@
     },
     "node_modules/prisma-6-language-server": {
       "name": "@prisma/language-server",
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-6.19.0.tgz",
-      "integrity": "sha512-9TE/0+4vq/7DK12tbWyyd4Hava6FMVPXO+DngOn8EPq7rWCsFlGwX2L1OprTRCtE+2s4yXRw75VSrQbcgbCnCA==",
+      "version": "6.19.0-hotfix.1",
+      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-6.19.0-hotfix.1.tgz",
+      "integrity": "sha512-3I5HiyEv5svyn5wZ+DJ0+Ht+mVVl58Q+YWzpCurZwi2QGDqAaD7vty4LDJ65iFWUMfQdFrQlSP0uZGOfrIngZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.19.0",
+        "@prisma/config": "6.19.0-dev.10",
         "@prisma/prisma-schema-wasm": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
-        "@prisma/schema-files-loader": "6.19.0",
+        "@prisma/schema-files-loader": "6.19.0-dev.10",
         "@types/js-levenshtein": "1.1.3",
         "js-levenshtein": "1.1.6",
         "klona": "2.0.6",
@@ -4378,9 +4378,9 @@
       }
     },
     "node_modules/prisma-6-language-server/node_modules/@prisma/config": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0.tgz",
-      "integrity": "sha512-zwCayme+NzI/WfrvFEtkFhhOaZb/hI+X8TTjzjJ252VbPxAl2hWHK5NMczmnG9sXck2lsXrxIZuK524E25UNmg==",
+      "version": "6.19.0-dev.10",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0-dev.10.tgz",
+      "integrity": "sha512-y3jJxFpPw8shOW+h1bpKIbEMrVOLOupcgzAxI+ixMOLzHH7041BYrotftRvAz/edQhEAeG2nAVDOyKS45o+H8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -4396,9 +4396,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/prisma-6-language-server/node_modules/@prisma/schema-files-loader": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.19.0.tgz",
-      "integrity": "sha512-5+TWqBFfEXwdinmNIjiZu5XyH5NlLWbZWmUaytSX3t7krHJStgl/F6T+rGzewMlXq0ievDoOoGgF7BQhUJh++Q==",
+      "version": "6.19.0-dev.10",
+      "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.19.0-dev.10.tgz",
+      "integrity": "sha512-FpjL53iN1ApEUyNbbaBJ2Yn575SMYiwplEeMpeSS4249DSf4O9B1l+RB6wLnXQ6Gk415GX4Y6+MWS3DAZfw4Ow==",
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/prisma-schema-wasm": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
@@ -9121,13 +9121,13 @@
       }
     },
     "prisma-6-language-server": {
-      "version": "npm:@prisma/language-server@6.19.0",
-      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-6.19.0.tgz",
-      "integrity": "sha512-9TE/0+4vq/7DK12tbWyyd4Hava6FMVPXO+DngOn8EPq7rWCsFlGwX2L1OprTRCtE+2s4yXRw75VSrQbcgbCnCA==",
+      "version": "npm:@prisma/language-server@6.19.0-hotfix.1",
+      "resolved": "https://registry.npmjs.org/@prisma/language-server/-/language-server-6.19.0-hotfix.1.tgz",
+      "integrity": "sha512-3I5HiyEv5svyn5wZ+DJ0+Ht+mVVl58Q+YWzpCurZwi2QGDqAaD7vty4LDJ65iFWUMfQdFrQlSP0uZGOfrIngZw==",
       "requires": {
-        "@prisma/config": "6.19.0",
+        "@prisma/config": "6.19.0-dev.10",
         "@prisma/prisma-schema-wasm": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
-        "@prisma/schema-files-loader": "6.19.0",
+        "@prisma/schema-files-loader": "6.19.0-dev.10",
         "@types/js-levenshtein": "1.1.3",
         "js-levenshtein": "1.1.6",
         "klona": "2.0.6",
@@ -9137,9 +9137,9 @@
       },
       "dependencies": {
         "@prisma/config": {
-          "version": "6.19.0",
-          "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0.tgz",
-          "integrity": "sha512-zwCayme+NzI/WfrvFEtkFhhOaZb/hI+X8TTjzjJ252VbPxAl2hWHK5NMczmnG9sXck2lsXrxIZuK524E25UNmg==",
+          "version": "6.19.0-dev.10",
+          "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0-dev.10.tgz",
+          "integrity": "sha512-y3jJxFpPw8shOW+h1bpKIbEMrVOLOupcgzAxI+ixMOLzHH7041BYrotftRvAz/edQhEAeG2nAVDOyKS45o+H8A==",
           "requires": {
             "c12": "3.1.0",
             "deepmerge-ts": "7.1.5",
@@ -9153,9 +9153,9 @@
           "integrity": "sha512-5au1UH9+jky4TtIdgxDUA9Mk+40R2hDwZnhjjzR1io7WFtIKP6e5DI7yQ5QVysY8Ves8KWDsvwzDOn6gYNY4iA=="
         },
         "@prisma/schema-files-loader": {
-          "version": "6.19.0",
-          "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.19.0.tgz",
-          "integrity": "sha512-5+TWqBFfEXwdinmNIjiZu5XyH5NlLWbZWmUaytSX3t7krHJStgl/F6T+rGzewMlXq0ievDoOoGgF7BQhUJh++Q==",
+          "version": "6.19.0-dev.10",
+          "resolved": "https://registry.npmjs.org/@prisma/schema-files-loader/-/schema-files-loader-6.19.0-dev.10.tgz",
+          "integrity": "sha512-FpjL53iN1ApEUyNbbaBJ2Yn575SMYiwplEeMpeSS4249DSf4O9B1l+RB6wLnXQ6Gk415GX4Y6+MWS3DAZfw4Ow==",
           "requires": {
             "@prisma/prisma-schema-wasm": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
             "fs-extra": "11.3.0"

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -28,7 +28,7 @@
     "hono": "4.7.10",
     "minimatch": "6.2.0",
     "openapi-fetch": "0.14.0",
-    "prisma-6-language-server": "npm:@prisma/language-server@6.19.0",
+    "prisma-6-language-server": "npm:@prisma/language-server@6.19.0-hotfix.1",
     "vscode-languageclient": "7.0.0",
     "watcher": "1.2.0",
     "zod": "3.24.3"


### PR DESCRIPTION
Updates the extension to use the Prisma 6 language server maintained from the `6.19.x-hotfix` branch. This is the branch we can use to release patches for Prisma 6.

Currently it [contains 3 commits](https://github.com/prisma/language-tools/compare/6.19.0..6.19.x-hotfix), one to set the version of the NPM package, one with the actual fix we want to backport and one updating a test fixture related to the fix.

I've released the language server by triggering the [3. Test Language Server and publish](https://github.com/prisma/language-tools/actions/runs/19678941726) manually with NPM channel set to `integration` (doesn't really matter what the channel is, I used integration because I didn't want to update our `latest` tag) and branch argument set to `6.19.x-hotfix`. The workflow uses the NPM trusted publisher setup so it's signed by Github. Also keep in mind that the publish job will use the version from `packages/language-server/package.json` when publishing.

Also did a manual test on the PR extension build to make sure that nothing's wrong with the published language server.