### PR TITLE
fix: fix change_readme.js use in PR build

### DIFF
--- a/.github/workflows/PR_build_extension.yml
+++ b/.github/workflows/PR_build_extension.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build all packages
         run: npm run compile
       - name: Replace Readme for marketplace
-        run: node scripts/change_readme.js dev
+        run: node scripts/change_readme.js insider
       - name: Update VS Code extension name
         run: |
           node scripts/update_package_json_file_PR_build.js


### PR DESCRIPTION
the script now takes the release channel, which should be `insider`