### PR TITLE
chore: fix patch branch build

### DIFF
--- a/scripts/setup_branch.sh
+++ b/scripts/setup_branch.sh
@@ -44,7 +44,7 @@ else
                 git checkout -f -b "$BRANCH"
             else
                 # Patch branch
-                NPM_VERSION=$(cat scripts/versions/prisma_latest)
+                NPM_VERSION=$(cat scripts/versions/tested_extension_stable)
                 echo "NPM_VERSION to base new branch on: $NPM_VERSION"
                 git checkout -f -b "$BRANCH" "$NPM_VERSION"
             fi


### PR DESCRIPTION
I think this should fix the patch release workflow ([failure here](https://github.com/prisma/language-tools/actions/runs/19965601393/job/57256453854#step:10:14)). It should now base the patch branch correctly on the latest stable release of the extension.