### PR TITLE
feat: opt out of language server for `// use prisma-next` files

### DIFF
--- a/packages/language-server/package.json
+++ b/packages/language-server/package.json
@@ -29,6 +29,16 @@
   },
   "main": "./dist/index.js",
   "typings": "dist/src/index",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./prisma-next": {
+      "types": "./dist/lib/prismaNext.d.ts",
+      "default": "./dist/lib/prismaNext.js"
+    }
+  },
   "dependencies": {
     "@prisma/config": "7.9.0-dev.4",
     "@prisma/prisma-schema-wasm": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",

--- a/packages/language-server/src/lib/prismaNext.ts
+++ b/packages/language-server/src/lib/prismaNext.ts
@@ -1,0 +1,5 @@
+const PRISMA_NEXT_DIRECTIVE = /^\s*\/\/ *use +prisma-next *(?!\S)/
+
+export function isPrismaNextSchema(text: string): boolean {
+  return PRISMA_NEXT_DIRECTIVE.test(text)
+}

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -22,6 +22,7 @@ import * as MessageHandler from './lib/MessageHandler'
 import type { LSOptions, LSSettings } from './lib/types'
 import { getVersion, getEnginesVersion, getCliVersion } from './lib/prisma-schema-wasm/internals'
 import { PrismaSchema } from './lib/Schema'
+import { isPrismaNextSchema } from './lib/prismaNext'
 
 const packageJson = require('../package.json') // eslint-disable-line
 
@@ -152,6 +153,11 @@ export function startServer(options?: LSOptions): void {
   }
 
   async function validateTextDocument(textDocument: TextDocument) {
+    if (isPrismaNextSchema(textDocument.getText())) {
+      await connection.sendDiagnostics({ uri: textDocument.uri, diagnostics: [] })
+      return
+    }
+
     const settings = await getDocumentSettings(textDocument.uri)
 
     if (settings.enableDiagnostics === false) {
@@ -171,7 +177,11 @@ export function startServer(options?: LSOptions): void {
   })
 
   function getDocument(uri: string): TextDocument | undefined {
-    return documents.get(uri)
+    const doc = documents.get(uri)
+    if (doc && isPrismaNextSchema(doc.getText())) {
+      return undefined
+    }
+    return doc
   }
 
   connection.onDefinition(async (params: DeclarationParams) => {

--- a/packages/language-server/src/server.ts
+++ b/packages/language-server/src/server.ts
@@ -165,7 +165,7 @@ export function startServer(options?: LSOptions): void {
       return
     }
 
-    const schema = await PrismaSchema.load({ currentDocument: textDocument, allDocuments: documents.all() })
+    const schema = await PrismaSchema.load({ currentDocument: textDocument, allDocuments: allRegularDocuments() })
     const diagnostics = MessageHandler.handleDiagnosticsRequest(schema, showErrorToast)
     for (const [uri, fileDiagnostics] of diagnostics.entries()) {
       await connection.sendDiagnostics({ uri, diagnostics: fileDiagnostics })
@@ -184,10 +184,14 @@ export function startServer(options?: LSOptions): void {
     return doc
   }
 
+  function allRegularDocuments(): TextDocument[] {
+    return documents.all().filter((d) => !isPrismaNextSchema(d.getText()))
+  }
+
   connection.onDefinition(async (params: DeclarationParams) => {
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
-      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: documents.all() })
+      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: allRegularDocuments() })
       return MessageHandler.handleDefinitionRequest(schema, doc, params)
     }
   })
@@ -195,7 +199,7 @@ export function startServer(options?: LSOptions): void {
   connection.onCompletion(async (params: CompletionParams) => {
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
-      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: documents.all() })
+      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: allRegularDocuments() })
       return MessageHandler.handleCompletionRequest(schema, doc, params, showErrorToast)
     }
   })
@@ -204,7 +208,7 @@ export function startServer(options?: LSOptions): void {
     const doc = getDocument(params.textDocument.uri)
 
     if (doc) {
-      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: documents.all() })
+      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: allRegularDocuments() })
 
       return MessageHandler.handleReferencesRequest(schema, params, showErrorToast)
     }
@@ -227,7 +231,7 @@ export function startServer(options?: LSOptions): void {
   connection.onHover(async (params: HoverParams) => {
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
-      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: documents.all() })
+      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: allRegularDocuments() })
       return MessageHandler.handleHoverRequest(schema, doc, params, showErrorToast)
     }
   })
@@ -235,7 +239,7 @@ export function startServer(options?: LSOptions): void {
   connection.onDocumentFormatting(async (params: DocumentFormattingParams) => {
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
-      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: documents.all() })
+      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: allRegularDocuments() })
       return MessageHandler.handleDocumentFormatting(schema, doc, params, showErrorToast)
     }
   })
@@ -243,7 +247,7 @@ export function startServer(options?: LSOptions): void {
   connection.onCodeAction(async (params: CodeActionParams) => {
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
-      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: documents.all() })
+      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: allRegularDocuments() })
       return MessageHandler.handleCodeActions(schema, doc, params, showErrorToast)
     }
   })
@@ -251,7 +255,7 @@ export function startServer(options?: LSOptions): void {
   connection.onRenameRequest(async (params: RenameParams) => {
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
-      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: documents.all() })
+      const schema = await PrismaSchema.load({ currentDocument: doc, allDocuments: allRegularDocuments() })
       return MessageHandler.handleRenameRequest(schema, doc, params)
     }
   })

--- a/packages/vscode/fixtures/highlighting/typesBlock.prisma
+++ b/packages/vscode/fixtures/highlighting/typesBlock.prisma
@@ -1,0 +1,7 @@
+// use prisma-next
+
+types {
+  Alias  = ExistingType @attribute
+  UserId = String       @id @default(cuid())
+  Email  = String       @unique
+}

--- a/packages/vscode/fixtures/linting/prismaNextDirective.prisma
+++ b/packages/vscode/fixtures/linting/prismaNextDirective.prisma
@@ -1,0 +1,8 @@
+// use prisma-next
+
+datasource db {
+}
+
+generator client {
+  provider = "prisma-client-js"
+}

--- a/packages/vscode/src/CodeLensProvider.ts
+++ b/packages/vscode/src/CodeLensProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as cp from 'child_process'
+import { isPrismaNextSchema } from './util'
 
 /**
  * CodelensProvider
@@ -22,6 +23,10 @@ export class CodelensProvider implements vscode.CodeLensProvider {
 
   public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {
     if (!this.enabled) {
+      return []
+    }
+
+    if (isPrismaNextSchema(document.getText())) {
       return []
     }
 

--- a/packages/vscode/src/__test__/language-server/prismaNext.test.ts
+++ b/packages/vscode/src/__test__/language-server/prismaNext.test.ts
@@ -1,19 +1,56 @@
 import * as vscode from 'vscode'
 import * as assert from 'assert'
-import { activate, getDocUri } from '../helper'
+import { activate, getDocUri, setTestContent } from '../helper'
+
+function waitForDiagnostics(
+  uri: vscode.Uri,
+  predicate: (d: readonly vscode.Diagnostic[]) => boolean,
+  timeoutMs = 5000,
+): Promise<readonly vscode.Diagnostic[]> {
+  return new Promise((resolve, reject) => {
+    const initial = vscode.languages.getDiagnostics(uri)
+    if (predicate(initial)) {
+      resolve(initial)
+      return
+    }
+    const target = uri.toString()
+    const sub = vscode.languages.onDidChangeDiagnostics((e) => {
+      if (!e.uris.some((u) => u.toString() === target)) return
+      const current = vscode.languages.getDiagnostics(uri)
+      if (predicate(current)) {
+        sub.dispose()
+        clearTimeout(timeout)
+        resolve(current)
+      }
+    })
+    const timeout = setTimeout(() => {
+      sub.dispose()
+      reject(new Error(`Diagnostics for ${target} did not match within ${timeoutMs}ms`))
+    }, timeoutMs)
+  })
+}
 
 suite('Prisma-next directive', () => {
-  test('Suppresses diagnostics on file with `// use prisma-next` directive', async () => {
+  test('Toggling the directive toggles diagnostics', async () => {
     const docUri = getDocUri('linting/prismaNextDirective.prisma')
     await activate(docUri)
-    const diagnostics = vscode.languages.getDiagnostics(docUri)
-    assert.deepStrictEqual(diagnostics, [], 'expected no diagnostics on prisma-next file')
+
+    // Remove the directive: the file should now produce diagnostics
+    // (empty datasource block triggers a missing-argument error). This
+    // also proves the LSP is alive within the test window.
+    await setTestContent('datasource db {\n}\n')
+    await waitForDiagnostics(docUri, (d) => d.length > 0)
+
+    // Re-add the directive: diagnostics must clear.
+    await setTestContent('// use prisma-next\n\ndatasource db {\n}\n')
+    const cleared = await waitForDiagnostics(docUri, (d) => d.length === 0)
+    assert.deepStrictEqual([...cleared], [], 'expected diagnostics to clear after adding directive')
   })
 
   test('Sibling file without directive still gets diagnostics', async () => {
     const docUri = getDocUri('linting/missingArgument.prisma')
     await activate(docUri)
-    const diagnostics = vscode.languages.getDiagnostics(docUri)
+    const diagnostics = await waitForDiagnostics(docUri, (d) => d.length > 0)
     assert.ok(diagnostics.length > 0, 'expected diagnostics on regular file with errors')
   })
 })

--- a/packages/vscode/src/__test__/language-server/prismaNext.test.ts
+++ b/packages/vscode/src/__test__/language-server/prismaNext.test.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode'
+import * as assert from 'assert'
+import { activate, getDocUri } from '../helper'
+
+suite('Prisma-next directive', () => {
+  test('Suppresses diagnostics on file with `// use prisma-next` directive', async () => {
+    const docUri = getDocUri('linting/prismaNextDirective.prisma')
+    await activate(docUri)
+    const diagnostics = vscode.languages.getDiagnostics(docUri)
+    assert.deepStrictEqual(diagnostics, [], 'expected no diagnostics on prisma-next file')
+  })
+
+  test('Sibling file without directive still gets diagnostics', async () => {
+    const docUri = getDocUri('linting/missingArgument.prisma')
+    await activate(docUri)
+    const diagnostics = vscode.languages.getDiagnostics(docUri)
+    assert.ok(diagnostics.length > 0, 'expected diagnostics on regular file with errors')
+  })
+})

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -30,6 +30,7 @@ import {
   checkForMinimalColorTheme,
   checkForOtherPrismaExtension,
   isDebugOrTestSession,
+  isPrismaNextSchema,
   isSnippetEdit,
   restartClient,
   createLanguageServer,
@@ -181,7 +182,22 @@ const plugin: PrismaVSCodePlugin = {
       },
     }
 
+    let started = false
+    const needsLanguageServer = (doc: TextDocument): boolean =>
+      doc.languageId === 'prisma' && !isPrismaNextSchema(doc.getText())
+
+    const maybeStart = () => {
+      if (started) return
+      if (!workspace.textDocuments.some(needsLanguageServer)) return
+      started = true
+      activateClient(context, clientOptions)
+    }
+
     const restartLanguageServer = async () => {
+      if (!started) {
+        maybeStart()
+        return
+      }
       const serverOptions = getServerOptions(workspace.getConfiguration('prisma'), context)
       client = await restartClient(context, client, serverOptions, clientOptions)
     }
@@ -233,9 +249,12 @@ const plugin: PrismaVSCodePlugin = {
         await restartLanguageServer()
         void window.showInformationMessage('Unpinned workspace from Prisma 6.')
       }),
+
+      workspace.onDidOpenTextDocument(() => maybeStart()),
+      workspace.onDidChangeTextDocument(() => maybeStart()),
     )
 
-    activateClient(context, clientOptions)
+    maybeStart()
 
     if (!isDebugOrTest) {
       const packageJSON = getPackageJSON(context)

--- a/packages/vscode/src/plugins/prisma-language-server/index.ts
+++ b/packages/vscode/src/plugins/prisma-language-server/index.ts
@@ -214,7 +214,9 @@ const plugin: PrismaVSCodePlugin = {
 
       commands.registerCommand('prisma.restartLanguageServer', async () => {
         await restartLanguageServer()
-        void window.showInformationMessage('Prisma language server restarted.')
+        if (started) {
+          void window.showInformationMessage('Prisma language server restarted.')
+        }
       }),
 
       commands.registerCommand('prisma.enableCodeLens', async () => {

--- a/packages/vscode/src/util.ts
+++ b/packages/vscode/src/util.ts
@@ -10,6 +10,7 @@ import {
 } from 'vscode'
 import { CodeAction, TextDocumentIdentifier, LanguageClientOptions } from 'vscode-languageclient'
 import { LanguageClient, ServerOptions } from 'vscode-languageclient/node'
+import { isPrismaNextSchema } from '@prisma/language-server/prisma-next'
 import { denyListDarkColorThemes, denyListLightColorThemes } from './denyListColorThemes'
 import { homedir } from 'os'
 import { readdirSync } from 'fs'
@@ -17,6 +18,8 @@ import path from 'path'
 export function isDebugOrTestSession(): boolean {
   return env.sessionId === 'someValue.sessionId'
 }
+
+export { isPrismaNextSchema }
 
 export function checkForOtherPrismaExtension(): void {
   const files = readdirSync(path.join(homedir(), '.vscode/extensions')).filter(

--- a/packages/vscode/syntaxes/prisma.tmLanguage.json
+++ b/packages/vscode/syntaxes/prisma.tmLanguage.json
@@ -14,6 +14,9 @@
       "include": "#multi_line_comment"
     },
     {
+      "include": "#types_block_definition"
+    },
+    {
       "include": "#model_block_definition"
     },
     {
@@ -203,6 +206,62 @@
             },
             "2": {
               "name": "entity.name.type.type.prisma"
+            },
+            "3": {
+              "name": "support.type.primitive.prisma"
+            }
+          }
+        },
+        {
+          "include": "#attribute_with_arguments"
+        },
+        {
+          "include": "#attribute"
+        }
+      ]
+    },
+    "types_block_definition": {
+      "begin": "^\\s*(types)\\s*({)",
+      "name": "source.prisma.embedded.source",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.types.prisma"
+        },
+        "2": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#triple_comment"
+        },
+        {
+          "include": "#double_comment"
+        },
+        {
+          "include": "#multi_line_comment"
+        },
+        {
+          "include": "#type_alias_definition"
+        }
+      ],
+      "end": "\\s*\\}",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.tag.prisma"
+        }
+      }
+    },
+    "type_alias_definition": {
+      "patterns": [
+        {
+          "match": "^\\s*(\\w+)\\s*(=)\\s*(\\w+)",
+          "captures": {
+            "1": {
+              "name": "entity.name.type.alias.prisma"
+            },
+            "2": {
+              "name": "keyword.operator.assignment.prisma"
             },
             "3": {
               "name": "support.type.primitive.prisma"


### PR DESCRIPTION
## Summary

- Adds a `// use prisma-next` magic comment that, when placed as the first non-whitespace line of a `.prisma` file, opts the file out of the existing PSL language server (no diagnostics, completions, formatting, hover, code actions, rename, references, definitions, document symbols, or CodeLens).
- Defers `LanguageClient` start until a non-prisma-next `.prisma` file is opened — if you only ever open prisma-next files, the language server process is never spawned.
- Adds TextMate highlighting for the new `types { Alias = ExistingType @attribute }` block introduced by prisma-next.

## How it works

A small shared helper `isPrismaNextSchema` (regex on the file head) is exposed via the new `@prisma/language-server/prisma-next` subpath export. The language server uses it inside `getDocument` (so all nine LSP request handlers naturally short-circuit) and at the top of `validateTextDocument` (which also clears stale diagnostics for files where the directive has just been added). The VS Code plugin uses it inside a lazy `maybeStart` that runs at activation time and on `onDidOpenTextDocument` / `onDidChangeTextDocument`, plus the `CodeLensProvider` to suppress the "Generate" lens.

Syntax highlighting comes from the TextMate grammar contribution, which is independent of the LSP, so prisma-next files keep their colors.

## Notes

- The `exports` field is new on `@prisma/language-server`; it explicitly lists the package root and the `./prisma-next` subpath, so importers can't accidentally pull the rest of the language server (and its WASM dependency) into the VS Code bundle.
- New integration tests in `packages/vscode/src/__test__/language-server/prismaNext.test.ts` assert that prisma-next files get zero diagnostics while sibling regular files still get them.