### PR TITLE
fix: normalize paths to use URI.toString() instead of fsPath Closes #1985

### DIFF
--- a/packages/language-server/src/__test__/path-normalization.test.ts
+++ b/packages/language-server/src/__test__/path-normalization.test.ts
@@ -1,13 +1,19 @@
 import { describe, it, expect } from 'vitest'
 import { URI } from 'vscode-uri'
+import { TextDocument } from 'vscode-languageserver-textdocument'
+import { PrismaSchema } from '../lib/Schema'
 
 describe('Path normalization for Windows compatibility (#1985)', () => {
-  it('old code: fsPath produces backslashes on Windows-style paths', () => {
+  it('old code: fsPath is platform-dependent', () => {
     const docUri = 'file:///C:/Users/juan/prisma/schema/user.prisma'
 
     const storedPath = URI.parse(docUri).fsPath
 
-    expect(typeof storedPath).toBe('string')
+    if (process.platform === 'win32') {
+      expect(storedPath).toContain('\\')
+    } else {
+      expect(storedPath).not.toContain('\\')
+    }
   })
 
   it('new code: toString() never produces backslashes', () => {
@@ -19,25 +25,51 @@ describe('Path normalization for Windows compatibility (#1985)', () => {
     expect(storedPath).toMatch(/^file:\/\//)
   })
 
-  it('Windows path with backslashes should produce forward slashes after normalization', () => {
+  it('URI.file() normalizes Windows backslash paths to forward-slash URIs', () => {
     const windowsPath = 'C:\\Users\\juan\\prisma\\schema\\user.prisma'
 
-    const normalized = windowsPath.replace(/\\/g, '/')
-
-    expect(windowsPath).toContain('\\')
+    const normalized = URI.file(windowsPath).toString()
 
     expect(normalized).not.toContain('\\')
-    expect(normalized).toBe('C:/Users/juan/prisma/schema/user.prisma')
+    expect(normalized).toMatch(/^file:\/\//)
   })
 
-  it('two URIs parsed and stringified should both lack backslashes', () => {
-    const uri1 = 'file:///C:/Users/juan/prisma/schema/user.prisma'
-    const uri2 = 'file:///C:/Users/juan/prisma/schema/user.prisma'
+  it('PrismaSchema preserves URI format when loading multi-file schema', async () => {
+    const baseUri = 'file:///C:/Users/juan/prisma/schema'
 
-    const normalized1 = URI.parse(uri1).toString()
-    const normalized2 = URI.parse(uri2).toString()
+    const userDoc = TextDocument.create(
+      `${baseUri}/User.prisma`,
+      'prisma',
+      1,
+      `model User {
+  id    String @id
+  name  String
+  posts Post[]
+}`,
+    )
 
-    expect(normalized1).not.toContain('\\')
-    expect(normalized2).not.toContain('\\')
+    const postDoc = TextDocument.create(
+      `${baseUri}/Post.prisma`,
+      'prisma',
+      1,
+      `model Post {
+  id       String @id
+  title    String
+  authorId String
+  author   User   @relation(fields: [authorId], references: [id])
+}`,
+    )
+
+    const schema = await PrismaSchema.load([userDoc, postDoc])
+
+    expect(schema.documents).toHaveLength(2)
+
+    for (const doc of schema.documents) {
+      expect(doc.uri).not.toContain('\\')
+      expect(doc.uri).toMatch(/^file:\/\//)
+    }
+
+    expect(schema.findDocByUri(userDoc.uri)).toBeDefined()
+    expect(schema.findDocByUri(postDoc.uri)).toBeDefined()
   })
 })

--- a/packages/language-server/src/__test__/path-normalization.test.ts
+++ b/packages/language-server/src/__test__/path-normalization.test.ts
@@ -60,6 +60,10 @@ describe('Path normalization for Windows compatibility (#1985)', () => {
 }`,
     )
 
+    // Note: Using array form because object form requires actual files on disk.
+    // The fix in createInMemoryResolver is exercised when loading from file paths,
+    // but we cannot test that here because Windows-style paths don't exist on Linux.
+    // The other tests in this file verify that toString() produces correct URIs.
     const schema = await PrismaSchema.load([userDoc, postDoc])
 
     expect(schema.documents).toHaveLength(2)

--- a/packages/language-server/src/__test__/path-normalization.test.ts
+++ b/packages/language-server/src/__test__/path-normalization.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { URI } from 'vscode-uri'
+
+describe('Path normalization for Windows compatibility (#1985)', () => {
+  it('old code: fsPath produces backslashes on Windows-style paths', () => {
+    const docUri = 'file:///C:/Users/juan/prisma/schema/user.prisma'
+
+    const storedPath = URI.parse(docUri).fsPath
+
+    expect(typeof storedPath).toBe('string')
+  })
+
+  it('new code: toString() never produces backslashes', () => {
+    const docUri = 'file:///C:/Users/juan/prisma/schema/user.prisma'
+
+    const storedPath = URI.parse(docUri).toString()
+
+    expect(storedPath).not.toContain('\\')
+    expect(storedPath).toMatch(/^file:\/\//)
+  })
+
+  it('Windows path with backslashes should produce forward slashes after normalization', () => {
+    const windowsPath = 'C:\\Users\\juan\\prisma\\schema\\user.prisma'
+
+    const normalized = windowsPath.replace(/\\/g, '/')
+
+    expect(windowsPath).toContain('\\')
+
+    expect(normalized).not.toContain('\\')
+    expect(normalized).toBe('C:/Users/juan/prisma/schema/user.prisma')
+  })
+
+  it('two URIs parsed and stringified should both lack backslashes', () => {
+    const uri1 = 'file:///C:/Users/juan/prisma/schema/user.prisma'
+    const uri2 = 'file:///C:/Users/juan/prisma/schema/user.prisma'
+
+    const normalized1 = URI.parse(uri1).toString()
+    const normalized2 = URI.parse(uri2).toString()
+
+    expect(normalized1).not.toContain('\\')
+    expect(normalized2).not.toContain('\\')
+  })
+})

--- a/packages/language-server/src/lib/Schema.ts
+++ b/packages/language-server/src/lib/Schema.ts
@@ -179,9 +179,9 @@ function createFilesResolver(allDocuments: TextDocument[]): FilesResolver {
 function createInMemoryResolver(allDocuments: TextDocument[], options: CaseSensitivityOptions): InMemoryFilesResolver {
   const resolver = new InMemoryFilesResolver(options)
   for (const doc of allDocuments) {
-    const filePath = URI.parse(doc.uri).toString()
+    const fileUri = URI.parse(doc.uri).toString()
     const content = doc.getText()
-    resolver.addFile(filePath, content)
+    resolver.addFile(fileUri, content)
   }
 
   return resolver

--- a/packages/language-server/src/lib/Schema.ts
+++ b/packages/language-server/src/lib/Schema.ts
@@ -111,8 +111,8 @@ export class PrismaSchema {
     if (Array.isArray(input)) {
       schemaDocs = input
     } else {
-      const fsPath = config?.schema ?? URI.parse(input.currentDocument.uri).toString()
-      schemaDocs = await loadSchemaDocumentsFromPath(fsPath, input.allDocuments)
+      const schemaUri = config?.schema ?? URI.parse(input.currentDocument.uri).toString()
+      schemaDocs = await loadSchemaDocumentsFromPath(schemaUri, input.allDocuments)
     }
     return new PrismaSchema(schemaDocs, config)
   }

--- a/packages/language-server/src/lib/Schema.ts
+++ b/packages/language-server/src/lib/Schema.ts
@@ -111,7 +111,7 @@ export class PrismaSchema {
     if (Array.isArray(input)) {
       schemaDocs = input
     } else {
-      const fsPath = config?.schema ?? URI.parse(input.currentDocument.uri).fsPath
+      const fsPath = config?.schema ?? URI.parse(input.currentDocument.uri).toString()
       schemaDocs = await loadSchemaDocumentsFromPath(fsPath, input.allDocuments)
     }
     return new PrismaSchema(schemaDocs, config)
@@ -179,7 +179,7 @@ function createFilesResolver(allDocuments: TextDocument[]): FilesResolver {
 function createInMemoryResolver(allDocuments: TextDocument[], options: CaseSensitivityOptions): InMemoryFilesResolver {
   const resolver = new InMemoryFilesResolver(options)
   for (const doc of allDocuments) {
-    const filePath = URI.parse(doc.uri).fsPath
+    const filePath = URI.parse(doc.uri).toString()
     const content = doc.getText()
     resolver.addFile(filePath, content)
   }


### PR DESCRIPTION
## Problem
On Windows, `URI.parse(uri).fsPath` returns paths with backslashes (`\`), while URIs always use forward slashes (`/`). When the language server compares these paths for deduplication, the mismatch causes multi-file schema discovery to fail
Fixes #1985

## Solution 
Use `URI.parse(uri).toString()` instead of `.fsPath` to ensure all paths use forward slashes consistently, matching the URI format.