### PR TITLE
chore: modernize GitHub Actions

### DIFF
--- a/.github/workflows/PR_build_extension.yml
+++ b/.github/workflows/PR_build_extension.yml
@@ -21,10 +21,13 @@ jobs:
     if: github.repository == 'prisma/language-tools'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.branch }}
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js

--- a/.github/workflows/PR_build_extension.yml
+++ b/.github/workflows/PR_build_extension.yml
@@ -21,18 +21,16 @@ jobs:
     if: github.repository == 'prisma/language-tools'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    outputs:
-      tag_name: ${{ steps.names.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.inputs.branch }}
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       # Build the extension
@@ -52,7 +50,7 @@ jobs:
 
       # Upload to the current job run
       # This is very limited: Only 90 days rentention and cannot get a link easily
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-artifact
           path: ./packages/vscode/*.vsix

--- a/.github/workflows/bump_prisma.yml
+++ b/.github/workflows/bump_prisma.yml
@@ -58,16 +58,16 @@ jobs:
               ;;
           esac
           echo "ref=$REF" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.validate.outputs.ref }}
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
@@ -78,7 +78,7 @@ jobs:
       - name: Update the lockfile
         run: pnpm install --no-frozen-lockfile
       - name: Upload the pinned manifests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pinned-manifests
           path: |
@@ -95,15 +95,17 @@ jobs:
       REF: ${{ needs.pin.outputs.ref }}
       PRISMA_VERSION: ${{ inputs.prisma_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.pin.outputs.ref }}
-          token: ${{ secrets.PRISMA_BOT_TOKEN }}
+          persist-credentials: false
       - name: Download the pinned manifests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pinned-manifests
       - name: Commit and push
+        env:
+          GH_TOKEN: ${{ secrets.PRISMA_BOT_TOKEN }}
         run: |
           if git diff --quiet; then
             echo "Dependencies are already pinned to $PRISMA_VERSION, nothing to commit."
@@ -111,4 +113,5 @@ jobs:
           fi
           sh scripts/set_git_credentials.sh
           git commit -am "bump Prisma CLI to $PRISMA_VERSION"
+          gh auth setup-git
           git push origin "HEAD:$REF"

--- a/.github/workflows/check_for_prisma_update.yml
+++ b/.github/workflows/check_for_prisma_update.yml
@@ -36,16 +36,16 @@ jobs:
       latest_version: ${{ steps.check_update.outputs.latest_version }}
       patch_dev_version: ${{ steps.check_update.outputs.patch-dev_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
@@ -64,14 +64,17 @@ jobs:
       LATEST_VERSION: ${{ needs.check.outputs.latest_version }}
       PATCH_DEV_VERSION: ${{ needs.check.outputs.patch_dev_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
-          token: ${{ secrets.PRISMA_BOT_TOKEN }}
           fetch-depth: 0 # patch branches are created from release tags
+          persist-credentials: false
       - name: Record new versions
+        env:
+          GH_TOKEN: ${{ secrets.PRISMA_BOT_TOKEN }}
         run: |
           sh scripts/set_git_credentials.sh
+          gh auth setup-git
           if [ -n "$DEV_VERSION" ]; then echo "$DEV_VERSION" > scripts/versions/prisma_dev; fi
           if [ -n "$LATEST_VERSION" ]; then echo "$LATEST_VERSION" > scripts/versions/prisma_latest; fi
           if [ -n "$PATCH_DEV_VERSION" ]; then echo "$PATCH_DEV_VERSION" > scripts/versions/prisma_patch-dev; fi
@@ -80,6 +83,8 @@ jobs:
       - name: Create the patch branch if it is new
         id: patch_branch
         if: needs.check.outputs.patch_dev_version
+        env:
+          GH_TOKEN: ${{ secrets.PRISMA_BOT_TOKEN }}
         run: |
           BRANCH=$(node scripts/setup_branch.mjs patch-dev)
           if [ -z "$(git ls-remote --heads origin "$BRANCH")" ]; then

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,11 +30,11 @@ jobs:
         language: ['javascript']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -43,4 +43,4 @@ jobs:
           # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,13 +36,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
@@ -55,7 +55,7 @@ jobs:
       - name: Run unit tests in all packages
         run: pnpm test
       - name: Run VS Code extension E2E tests in headless mode
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
         with:
           run: pnpm test:e2e
 
@@ -66,7 +66,7 @@ jobs:
           npx playwright install chromium
 
       - name: Run Playwright UI tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
         with:
           run: pnpm test:playwright
           working-directory: packages/vscode
@@ -74,7 +74,7 @@ jobs:
           CI: true
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           name: playwright-report-${{ matrix.os }}
@@ -87,7 +87,7 @@ jobs:
       - name: Catch version incompatibilities
         if: matrix.os == 'ubuntu-latest'
         run: pnpm test:scripts
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./scripts/__tests__/coverage/clover.xml,./packages/language-server/coverage/clover.xml
           flags: ${{ matrix.os }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,11 +32,15 @@ jobs:
     name: Tests + Shellcheck
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js

--- a/.github/workflows/e2e_check_for_new_published_vsix.yml
+++ b/.github/workflows/e2e_check_for_new_published_vsix.yml
@@ -8,6 +8,9 @@ on:
   #   - cron: '*/10 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check-version:
     name: Check for new version
@@ -15,6 +18,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js

--- a/.github/workflows/e2e_check_for_new_published_vsix.yml
+++ b/.github/workflows/e2e_check_for_new_published_vsix.yml
@@ -14,15 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PRISMA_BOT_TOKEN }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
@@ -32,18 +30,21 @@ jobs:
           node scripts/e2eTestsOnVsix/check_marketplace_version.mjs
       - name: Check new release of stable and Insider
         id: check_published_version
+        env:
+          INSIDER_VERSION: ${{ steps.versions.outputs.insider_version }}
+          STABLE_VERSION: ${{ steps.versions.outputs.stable_version }}
         run: |
-          node scripts/e2eTestsOnVsix/check_for_new_release.mjs ${{ steps.versions.outputs.insider_version }} ${{ steps.versions.outputs.stable_version }}
+          node scripts/e2eTestsOnVsix/check_for_new_release.mjs "$INSIDER_VERSION" "$STABLE_VERSION"
       - name: Trigger e2e tests for Insider
         if: ${{ steps.check_published_version.outputs.new_insider_version }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@d004979be141727c7a17c28f603e2facc40d0855 # v1.3.3
         with:
           workflow: E2E tests after release on VSIX
           token: ${{ secrets.PRISMA_BOT_TOKEN }}
           inputs: '{ "extension_type": "insider", "extension_version": "${{ steps.check_published_version.outputs.new_insider_version }}" }'
       - name: Trigger e2e tests for stable
         if: ${{ steps.check_published_version.outputs.new_stable_version }}
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@d004979be141727c7a17c28f603e2facc40d0855 # v1.3.3
         with:
           workflow: E2E tests after release on VSIX
           token: ${{ secrets.PRISMA_BOT_TOKEN }}

--- a/.github/workflows/e2e_published_vsix.yml
+++ b/.github/workflows/e2e_published_vsix.yml
@@ -11,6 +11,9 @@ on:
         description: 'VS Code extension version'
         required: true
 
+permissions:
+  contents: read
+
 env:
   ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
   EXTENSION_TYPE: ${{ inputs.extension_type }}
@@ -31,6 +34,8 @@ jobs:
       installed-extension: ${{ steps.install.outputs.installed-extension }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
@@ -57,6 +62,8 @@ jobs:
     if: always()
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: echo new version
         env:
           INSTALLED_EXTENSION: ${{ needs.test.outputs.installed-extension }}

--- a/.github/workflows/e2e_published_vsix.yml
+++ b/.github/workflows/e2e_published_vsix.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
+  EXTENSION_TYPE: ${{ inputs.extension_type }}
+  EXTENSION_VERSION: ${{ inputs.extension_version }}
   # * Enables github logging
   # ACTIONS_STEP_DEBUG: true
 
@@ -28,27 +30,25 @@ jobs:
     outputs:
       installed-extension: ${{ steps.install.outputs.installed-extension }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PRISMA_BOT_TOKEN }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
       - name: Install extension via CLI
         id: install
         run: |
-          node scripts/e2eTestsOnVsix/install_extension.mjs ${{ github.event.inputs.extension_type }} ${{ github.event.inputs.extension_version }}
+          node scripts/e2eTestsOnVsix/install_extension.mjs "$EXTENSION_TYPE" "$EXTENSION_VERSION"
       - name: Run test
         if: ${{ steps.install.outputs.installed-extension }}
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
         with:
-          run: pnpm test:e2e:vsix ${{ github.event.inputs.extension_type }} ${{ matrix.os }} ${{ github.event.inputs.extension_version }}
+          run: pnpm test:e2e:vsix "$EXTENSION_TYPE" "${{ matrix.os }}" "$EXTENSION_VERSION"
 
   after-test:
     name: Bump tested version and commit # scripts/versions/tested_extension_stable & tested_extension_insider
@@ -56,13 +56,13 @@ jobs:
     needs: [test]
     if: always()
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PRISMA_BOT_TOKEN }}
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: echo new version
-        run: echo ${{ needs.test.outputs.installed-extension }}
+        env:
+          INSTALLED_EXTENSION: ${{ needs.test.outputs.installed-extension }}
+        run: echo "$INSTALLED_EXTENSION"
       - name: Bump version
         if: ${{needs.test.result == 'success' && needs.test.outputs.installed-extension }}
-        run: pnpm test:e2e:bump ${{ github.event.inputs.extension_type }} ${{ github.event.inputs.extension_version }}
+        run: pnpm test:e2e:bump "$EXTENSION_TYPE" "$EXTENSION_VERSION"
         env:
           GH_TOKEN: ${{ secrets.PRISMA_BOT_TOKEN }} # Needed and used in the shell script behind test:bump

--- a/.github/workflows/pr-code-security.yml
+++ b/.github/workflows/pr-code-security.yml
@@ -7,8 +7,8 @@ on:
 jobs:
   secret-detection:
     name: Secret Detection
-    uses: prisma/.github/.github/workflows/secret_detection.yml@main
+    uses: prisma/.github/.github/workflows/secret_detection.yml@7e808313ce87dfbd166654e9819606097a68d8c8 # main (2026-05-26)
     secrets: inherit
   code-scanning:
     name: Code Scanning
-    uses: prisma/.github/.github/workflows/code_scanning.yml@main
+    uses: prisma/.github/.github/workflows/code_scanning.yml@7e808313ce87dfbd166654e9819606097a68d8c8 # main (2026-05-26)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ permissions:
 env:
   ENVIRONMENT: ${{ secrets.ENVIRONMENT }}
   PRISMA_TELEMETRY_INFORMATION: 'language-tools release.yml'
-  NODE_VERSION: '22'
+  NODE_VERSION: '24'
 
 jobs:
   plan:
@@ -98,15 +98,15 @@ jobs:
             echo "channel=$CHANNEL"
             echo "ref=$REF"
           } >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.params.outputs.ref }}
           fetch-depth: 0 # all branches and tags: the next version is derived from release tags
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -131,14 +131,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.plan.outputs.sha }}
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -151,7 +151,7 @@ jobs:
       - name: Run Language Server tests
         run: pnpm --filter @prisma/language-server test
       - name: Headless E2E tests
-        uses: coactions/setup-xvfb@v1
+        uses: coactions/setup-xvfb@b6b4fcfb9f5a895edadc3bc76318fae0ac17c8b3 # v1.0.1
         with:
           run: pnpm test:e2e
 
@@ -168,23 +168,23 @@ jobs:
       VERSION: ${{ needs.plan.outputs.version }}
       LS_NPM_TAG: ${{ needs.plan.outputs.ls_npm_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.plan.outputs.sha }}
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-      - name: Update npm to support Trusted Publishers
-        run: npm install -g npm@^11.5
+      - name: Update npm to support trusted publishing
+        run: npm install -g npm@^11.5.1
       - name: Install Dependencies
         run: pnpm install
       - name: Set Language Server version
-        run: node scripts/update_package_json_files.mjs "$NPM_CHANNEL" "$VERSION" ""
+        run: node scripts/update_package_json_files.mjs "$NPM_CHANNEL" "$VERSION"
       - name: Build Language Server
         run: pnpm --filter @prisma/language-server build
       - name: Publish Language Server to npm
@@ -201,21 +201,21 @@ jobs:
       VERSION: ${{ needs.plan.outputs.version }}
       ASSET_FILE: ${{ needs.plan.outputs.asset_name }}-${{ needs.plan.outputs.version }}.vsix
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.plan.outputs.sha }}
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
       - name: Set extension name and version
-        run: node scripts/update_package_json_files.mjs "$NPM_CHANNEL" "$VERSION" ""
+        run: node scripts/update_package_json_files.mjs "$NPM_CHANNEL" "$VERSION"
       - name: Replace Readme for marketplace
         run: node scripts/change_readme.mjs "$CHANNEL"
       - name: Build all packages
@@ -223,7 +223,7 @@ jobs:
       - name: Build vsix
         run: cd packages/vscode && pnpm package
       - name: Upload vsix as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vsix
           path: packages/vscode/${{ env.ASSET_FILE }}
@@ -245,7 +245,7 @@ jobs:
       GH_REPO: ${{ github.repository }}
     steps:
       - name: Download vsix artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
       - name: Create GitHub release
@@ -265,21 +265,21 @@ jobs:
     env:
       ASSET_FILE: ${{ needs.plan.outputs.asset_name }}-${{ needs.plan.outputs.version }}.vsix
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.plan.outputs.sha }}
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
       - name: Download vsix artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
       - name: Publish vsix to marketplace
@@ -295,21 +295,21 @@ jobs:
     env:
       ASSET_FILE: ${{ needs.plan.outputs.asset_name }}-${{ needs.plan.outputs.version }}.vsix
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.plan.outputs.sha }}
           persist-credentials: false
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
       - name: Install Dependencies
         run: pnpm install
       - name: Download vsix artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vsix
       - name: Publish vsix to open-vsx.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,4 +313,5 @@ jobs:
       - name: Publish vsix to open-vsx.org
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_ACCESS_TOKEN }}
-        run: cd packages/vscode && npx ovsx --debug publish "$GITHUB_WORKSPACE/$ASSET_FILE"
+        run: >-
+          cd packages/vscode && npx ovsx --debug publish "$GITHUB_WORKSPACE/$ASSET_FILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,8 +179,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
-      - name: Update npm to support trusted publishing
-        run: npm install -g npm@^11.5.1
       - name: Install Dependencies
         run: pnpm install
       - name: Set Language Server version

--- a/.github/workflows/update-api-types.yml
+++ b/.github/workflows/update-api-types.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.PRISMA_BOT_TOKEN }}
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install Dependencies
@@ -60,6 +60,9 @@ jobs:
 
       - name: Commit and push if changes exist
         if: steps.git-check.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PRISMA_BOT_TOKEN }}
         run: |
           git commit -m "chore: update generated API types"
+          gh auth setup-git
           git push

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "31.12.2",
   "author": "Prisma",
   "license": "Apache-2.0",
-  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
+  "packageManager": "pnpm@11.25.0+sha512.5cde925b4f075f725eb71fbae18a42ffe784524789f19b61c731cb8721ec28aaee160e01a8d5af4fedb2a42cdbf300efe23db356b0d4a17b4d63e11f8ab7c956",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=10"
+    "pnpm": ">=11"
   },
   "devDependencies": {
     "@actions/core": "1.11.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,10 @@
 packages:
   - 'packages/*'
   - 'packages/vscode/tests/fixtures/integration-workspace/*'
+
+allowBuilds:
+  '@vscode/vsce-sign': true
+  esbuild: true
+  keytar: true
+  msgpackr-extract: true
+  workerd: true


### PR DESCRIPTION
Modernizes the repository's GitHub Actions toolchain, hardens action references against upstream tag movement, and fixes the release packaging failure seen in [run 33765314608](https://github.com/prisma/language-tools/actions/runs/33765314608/job/100683085687).

## Changes

- **Actions security and runtime**: Updates every action and reusable workflow to its latest stable release, pins all 62 references to immutable commit SHAs, and moves workflows to Node.js 24.
- **Package manager**: Pins pnpm 11.25.0 and explicitly allows only the dependency build scripts required by this workspace.
- **Release reliability**: Fixes both `update_package_json_files.mjs` invocations to pass the script's expected two arguments. Uses the npm bundled with Node 24, matching npm’s current trusted-publishing guidance.
- **Bot credentials**: Removes `PRISMA_BOT_TOKEN` from checkout steps. Workflows that must push or dispatch still authenticate explicitly at those operations so bot-authored pushes continue to trigger downstream workflows.

## Why

Full-SHA action pins prevent mutable tags from changing CI behavior unexpectedly. Node 24 and pnpm 11 remove deprecated action runtimes while the narrow pnpm build allowlist preserves supply-chain safeguards. Explicit push-time bot authentication limits credential persistence without changing release automation behavior.

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm test:scripts` (19 tests passed)
- `corepack pnpm exec prettier --check '.github/workflows/*.{yml,yaml}' package.json pnpm-workspace.yaml`
- YAML/LSP diagnostics for all changed workflow and config files
- `git diff --check`
- Verified all 62 `uses:` references are full-SHA pinned with comments
- Verified workflows contain no Node 20/22 setup, dangerous pnpm build bypass, extra release-script argument, or bot token passed to checkout

